### PR TITLE
Add slashes to the end of index pages in the sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,6 @@
 <ul class="sidebar">
   <li>
-    <a href="{{ '/IDE' | prepend: site.baseurl }}">IDE</a>
+    <a href="{{ '/IDE/' | prepend: site.baseurl }}">IDE</a>
     <ul>
       <li><a href="{{ '/IDE/code_checking' | prepend: site.baseurl }}">Code Checking</a></li>
       <li><a href="{{ '/IDE/creating_a_project' | prepend: site.baseurl }}">Code a Project</a></li>
@@ -12,11 +12,11 @@
     </ul>
   </li>
   <li>
-    <a href="{{ '/kit' | prepend: site.baseurl }}">Kits</a>
+    <a href="{{ '/kit/' | prepend: site.baseurl }}">Kits</a>
     <ul>
       <li><a href="{{ '/kit/assembly' | prepend: site.baseurl }}">Assembly</a></li>
       <li>
-        <a href="{{ '/kit/batteries' | prepend: site.baseurl }}">Batteries</a>
+        <a href="{{ '/kit/batteries/' | prepend: site.baseurl }}">Batteries</a>
         <ul>
           <li><a href="{{ '/kit/batteries/hke4_charger' | prepend: site.baseurl }}">HKE4 Charger</a></li>
           <li><a href="{{ '/kit/batteries/imax_b6_charger' | prepend: site.baseurl }}">IMAX B6 Charger</a></li>
@@ -32,29 +32,29 @@
     </ul>
   </li>
   <li>
-    <a href="{{ '/programming' | prepend: site.baseurl }}">Programming</a>
+    <a href="{{ '/programming/' | prepend: site.baseurl }}">Programming</a>
     <ul>
       <li>
-        <a href="{{ '/programming/python' | prepend: site.baseurl }}">Python</a>
+        <a href="{{ '/programming/python/' | prepend: site.baseurl }}">Python</a>
         <ul>
           <li><a href="{{ '/programming/python/functions' | prepend: site.baseurl }}">Functions</a></li>
           <li><a href="{{ '/programming/python/libraries' | prepend: site.baseurl }}">Libraries</a></li>
         </ul>
       </li>
       <li>
-        <a href="{{ '/programming/sr' | prepend: site.baseurl }}">sr</a>
+        <a href="{{ '/programming/sr/' | prepend: site.baseurl }}">sr</a>
         <ul>
           <li><a href="{{ '/programming/sr/motors' | prepend: site.baseurl }}">Motors</a></li>
           <li><a href="{{ '/programming/sr/power' | prepend: site.baseurl }}">Power</a></li>
           <li>
-            <a href="{{ '/programming/sr/ruggeduinos' | prepend: site.baseurl }}">Ruggeduinos</a>
+            <a href="{{ '/programming/sr/ruggeduinos/' | prepend: site.baseurl }}">Ruggeduinos</a>
             <ul>
               <li><a href="{{ '/programming/sr/ruggeduinos/custom_firmware' | prepend: site.baseurl }}">Custom Firmware</a></li>
             </ul>
           </li>
           <li><a href="{{ '/programming/sr/servos' | prepend: site.baseurl }}">Servos</a></li>
           <li>
-            <a href="{{ '/programming/sr/vision' | prepend: site.baseurl }}">Vision</a>
+            <a href="{{ '/programming/sr/vision/' | prepend: site.baseurl }}">Vision</a>
             <ul>
               <li><a href="{{ '/programming/sr/vision/markers' | prepend: site.baseurl }}">Markers</a></li>
             </ul>
@@ -67,14 +67,14 @@
   </li>
   <li><a href="{{ '/rules' | prepend: site.baseurl }}">Rules</a></li>
   <li>
-    <a href="{{ '/troubleshooting' | prepend: site.baseurl }}">Troubleshooting</a>
+    <a href="{{ '/troubleshooting/' | prepend: site.baseurl }}">Troubleshooting</a>
     <ul>
       <li><a href="{{ '/troubleshooting/python' | prepend: site.baseurl }}">Python</a></li>
       <li><a href="{{ '/troubleshooting/interactive_troubleshooter' | prepend: site.baseurl }}">Interactive Troubleshooter</a></li>
     </ul>
   </li>
   <li>
-    <a href="{{ '/tutorials' | prepend: site.baseurl }}">Tutorials</a>
+    <a href="{{ '/tutorials/' | prepend: site.baseurl }}">Tutorials</a>
     <ul>
       <li><a href="{{ '/tutorials/basic_motor_control' | prepend: site.baseurl }}">Basic Motor Control</a></li>
       <li><a href="{{ '/tutorials/python' | prepend: site.baseurl }}">Python</a></li>


### PR DESCRIPTION
While behind the reverse proxy, the sidebar currently redirects users out to srobo.github.io when they click on links which point to indexes of folders.

This doesn't fix the problem (which is Github Pages' fault), but it makes the sidebar usable.