### PR TITLE
Added slashes to the remaining redirecting links

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -44,15 +44,15 @@
       <li>
         <a href="{{ '/programming/sr/' | prepend: site.baseurl }}">sr</a>
         <ul>
-          <li><a href="{{ '/programming/sr/motors' | prepend: site.baseurl }}">Motors</a></li>
-          <li><a href="{{ '/programming/sr/power' | prepend: site.baseurl }}">Power</a></li>
+          <li><a href="{{ '/programming/sr/motors/' | prepend: site.baseurl }}">Motors</a></li>
+          <li><a href="{{ '/programming/sr/power/' | prepend: site.baseurl }}">Power</a></li>
           <li>
             <a href="{{ '/programming/sr/ruggeduinos/' | prepend: site.baseurl }}">Ruggeduinos</a>
             <ul>
               <li><a href="{{ '/programming/sr/ruggeduinos/custom_firmware' | prepend: site.baseurl }}">Custom Firmware</a></li>
             </ul>
           </li>
-          <li><a href="{{ '/programming/sr/servos' | prepend: site.baseurl }}">Servos</a></li>
+          <li><a href="{{ '/programming/sr/servos/' | prepend: site.baseurl }}">Servos</a></li>
           <li>
             <a href="{{ '/programming/sr/vision/' | prepend: site.baseurl }}">Vision</a>
             <ul>
@@ -65,7 +65,7 @@
       <li><a href="{{ '/programming/simulator' | prepend: site.baseurl }}">Simulator</a></li>
     </ul>
   </li>
-  <li><a href="{{ '/rules' | prepend: site.baseurl }}">Rules</a></li>
+  <li><a href="{{ '/rules/' | prepend: site.baseurl }}">Rules</a></li>
   <li>
     <a href="{{ '/troubleshooting/' | prepend: site.baseurl }}">Troubleshooting</a>
     <ul>


### PR DESCRIPTION
There are some more links which, when clicked on behind the reverse proxy, redirect to srobo.github.io. This fixes those.