### PR TITLE
Ensure tablet page images are size limited

### DIFF
--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -65,6 +65,7 @@
     display: block;
     margin: 0 auto;
     width: initial;
+    max-width: 100%;
 
     &.left {
       float: left;


### PR DESCRIPTION
This was in the original patch, but appeared unneccesary in the new docs CSS.
It turns out that it is needed after all.

Change-Id: Ia1402a2d8d0496ac80e25a095d298f9e699d8a36