### PR TITLE
Ensure h2 headings clear floated elements

### DIFF
--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -9,6 +9,7 @@
   h2 {
     font-size: $delta;
     margin: 2em 0 1em;
+    clear: both;
   }
 
   h3 {


### PR DESCRIPTION
Some of the kit pages have a floated photo of the piece of kit and the
following header should clear the image.

@jimmythompson I'm not sure if this is the correct way to solve this problem. I know the old website was full of clears, but since the new website and the docs have very few clears I suspect that maybe they are not good?
