### PR TITLE
You must use Chrome Shell on the tablet

### DIFF
--- a/kit/wifi.md
+++ b/kit/wifi.md
@@ -35,6 +35,7 @@ Interacting With Your Robot
 ---------------------------
 
 Once you have a WiFi connection, visit `http://robot.sr` in a web browser to see the robot interface.
+If you are using the tablet provided with your kit you will need to use `Chrome Shell` rather than the default web browser.
 
 The robot interface gives you the ability to remotely start the code on your robot,
 as well as view the logs.


### PR DESCRIPTION
The tablets have the old pre-chrome Android browser on them and it has
no features and supports nothing. We install 'Chrome Shell' onto the
tablets which does have features and does support things.