### PR TITLE
Remove references to the rules

### DIFF
--- a/programming/sr/vision/markers.md
+++ b/programming/sr/vision/markers.md
@@ -16,10 +16,9 @@ Let's break that down:
 `(v0.5)` tells you the version of the marker, it is important the latest version is used; and
 `'ARENA'` is just a human-readable description of what the marker is for.
 
-Details of the types and size of markers used in the SR2017 game can be found in the [rules](/docs/rules).
+Details of the types and size of markers used in this year's game will be 
+available in the [rules](/docs/rules), when they are published.
 
-You can download all of the markers as a single [ZIP file](/docs/resources/2017/sr-dev-markers-sr2017.zip)
-or individually from the [git repo](https://github.com/srobo/game-markers/tree/master/SR2017/dev).
 The *Arena* and *Token* markers, due to their size, need to be printed on A3 paper.
 You must ensure that your PDF viewer is not resizing the documents when printing.
 This can be checked by measuring the grey box around the marker and comparing this to the size defined in the rules.

--- a/rules/index.md
+++ b/rules/index.md
@@ -1,14 +1,9 @@
 ---
 layout: page
-title: 2017 Rules
+title: 2019 Rules
 ---
 
-2017 Rules
+2019 Rules
 ==========
 
-[<img class="left" src="{{ site.baseurl }}/resources/2017/rulebook.png" />]({{ site.baseurl }}/resources/2017/rulebook.pdf)
-The rules, regulations and specifications for the SR2017 competition can be
-found in the [rulebook]({{ site.baseurl }}/resources/2017/rulebook.pdf).
-
-The PDF may be subject to minor changes, so please ensure you're using the most up-to-date version.
-We will also let you know of any important changes by email.
+The rules for this year's competition will be published shortly after Kickstart.


### PR DESCRIPTION
This explains the rules are not yet published for the SR2019 competition.