### PR TITLE
Allow horizontal scrolling on code blocks

### DIFF
--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -3,6 +3,7 @@
  */
 .highlight {
     background: #fff;
+    overflow-x: auto;
 
     .highlighter-rouge & {
       background: #eef;


### PR DESCRIPTION
Fixes code examples getting cut off when the lines are long, e.g.

<img width="751" alt="screenshot 2018-11-10 at 15 55 54" src="https://user-images.githubusercontent.com/653864/48303408-c7865e00-e501-11e8-80b3-65c5c1cf727a.png">
