### PR TITLE
Remove the inexistant interactive troubleshooter

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -72,7 +72,6 @@
     <a href="{{ '/troubleshooting/' | prepend: site.baseurl }}">Troubleshooting</a>
     <ul>
       <li><a href="{{ '/troubleshooting/python' | prepend: site.baseurl }}">Python</a></li>
-      <li><a href="{{ '/troubleshooting/interactive_troubleshooter' | prepend: site.baseurl }}">Interactive Troubleshooter</a></li>
     </ul>
   </li>
   <li>


### PR DESCRIPTION
Turns out the interactive troubleshooter didn't make it over to the
'new' website, we probably shouldn't link to it.