### PR TITLE
Require bundler 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Student Robotics public documentation.
 2. Install Bundler (1.x) and Rake
 
     ``` shell
-    $ gem install bundler -v '~> 1' rake
+    $ gem install 'bundler:~>1' rake
     ```
 
 3. Start the app in development mode

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The Student Robotics public documentation.
 
 1. [Install Ruby][install-ruby]
 
-2. Install Bundler and Rake
+2. Install Bundler (1.x) and Rake
 
     ``` shell
-    $ gem install bundler rake
+    $ gem install bundler -v '~> 1' rake
     ```
 
 3. Start the app in development mode


### PR DESCRIPTION
Version 2.x has a whole new file format which we don't want to switch over to yet as it would break a bunch of developer's setups.