### PR TITLE
Document buffer overflow bug on Power Board

### DIFF
--- a/kit/power_board.md
+++ b/kit/power_board.md
@@ -87,6 +87,11 @@ The case measures 83x99x24mm. Don't forget that the cables will stick out.
 
 [^2]: If overall current limit is exceeded, the Power Board will turn off and start beeping.
 
+Notes
+-----
+
+There is an internal ring buffer that stores a queue of buzzes for the Piezo buzzer. If the number of buzzes queued exceeds 32, the buffer may overflow and cause your code to crash. This is a known issue with the board.
+
 
 Designs
 -------


### PR DESCRIPTION
When the sample ring buffer in [piezo.c](https://www.studentrobotics.org/cgit/boards/power-v4-fw.git/tree/piezo.c#n22) overflows, the code will crash and cause a reset of the board.

Teams have come across this and were asking about it at the Tech Day.

Closes #97 