### PR TITLE
Update URLs of board firmware and hardware repositories

### DIFF
--- a/kit/motor_board.md
+++ b/kit/motor_board.md
@@ -57,5 +57,5 @@ You can access the schematics and source code of the firmware on the motor board
 You do not need this information to use the board but it may be of interest to some people.
 
  * [Full Schematics]({{ site.baseurl }}/resources/kit/motor-schematic.pdf)
- * [Firmware Source](https://www.studentrobotics.org/cgit/boards/motor-v4-fw.git/)
- * [Hardware Designs](https://www.studentrobotics.org/cgit/boards/motor-v4-hw.git/)
+ * [Firmware Source](https://github.com/srobo/motor-v4-fw)
+ * [Hardware Designs](https://github.com/srobo/motor-v4-hw)

--- a/kit/power_board.md
+++ b/kit/power_board.md
@@ -95,5 +95,5 @@ You can access the schematics and source code of the firmware for the power boar
 You do not need this information to use the board but it may be of interest to some people.
 
 * [Full Schematics]({{ site.baseurl }}/resources/kit/power-schematic.pdf)
-* [Firmware source](https://www.studentrobotics.org/cgit/boards/power-v4-fw.git/)
-* [Hardware designs](https://www.studentrobotics.org/cgit/boards/power-v4-hw.git/)
+* [Firmware source](https://github.com/srobo/power-v4-fw)
+* [Hardware designs](https://github.com/srobo/power-v4-hw)

--- a/kit/servo_board.md
+++ b/kit/servo_board.md
@@ -58,5 +58,5 @@ You can access the schematics and source code of the firmware on the servo board
 You do not need this information to use the board but it may be of interest to some people.
 
 * [Full Schematics]({{ site.baseurl }}/resources/kit/servo-schematic.pdf)
-* [Firmware source](https://www.studentrobotics.org/cgit/boards/servo-v4-fw.git/)
-* [Hardware designs](https://www.studentrobotics.org/cgit/boards/servo-v4-hw.git/)
+* [Firmware source](https://github.com/srobo/servo-v4-fw)
+* [Hardware designs](https://github.com/srobo/servo-v4-hw)


### PR DESCRIPTION
These repositories were recently moved from legacy cgit to github.