### PR TITLE
Correct supported versions of Python

### DIFF
--- a/competition-simulator/index.md
+++ b/competition-simulator/index.md
@@ -19,7 +19,17 @@ For SR2020, a virtual competition will be run using a brand new simulator.
 
 This simulation is based in [Webots](https://cyberbotics.com/#download), which will need to be downloaded and installed. The download is around 1.5GB.
 
-You will also need [Python 3.7 64-bit](https://www.python.org/downloads/release/python-377/) installed. Additional external libraries are not supported.
+#### Python Version
+
+You will also need Python installed. Additional external libraries are not supported.
+
+| Platform | Supported Python Version |
+|----------|--------------------------|
+| Windows  | 3.7 (64-bit)             |
+| macOS    | >= 3.7                   |
+| Linux    | >= 3.5                   |
+
+In the competition, Python 3.7 will be used.
 
 ### Installing the simulation
 


### PR DESCRIPTION
Webots support is a little strange.

This PR also commits to 3.7 in the event, which is supported on all platforms.

Further fixes https://github.com/srobo/competition-simulator/issues/89

Fixes https://github.com/srobo/competition-simulator/pull/92
Fixes https://github.com/srobo/competition-simulator/pull/91