### PR TITLE
Let competitors request external libraries in the simulator

### DIFF
--- a/competition-simulator/index.md
+++ b/competition-simulator/index.md
@@ -21,7 +21,7 @@ This simulation is based in [Webots](https://cyberbotics.com/#download), which w
 
 #### Python Version
 
-You will also need Python installed. Additional external libraries are not supported.
+You will also need Python installed.
 
 | Platform | Supported Python Version |
 |----------|--------------------------|
@@ -30,6 +30,11 @@ You will also need Python installed. Additional external libraries are not suppo
 | Linux    | >= 3.5                   |
 
 In the competition, Python 3.7 will be used.
+
+Currently no [external libraries]({{ site.baseurl}}/programming/python/libraries)
+are provided, however if there are libraries which you need you can request
+their inclusion [via the forums](/forum) (please include a link to the package
+on [PyPI](https://pypi.org/)).
 
 ### Installing the simulation
 

--- a/programming/python/libraries.md
+++ b/programming/python/libraries.md
@@ -6,6 +6,17 @@ title: Included Python Libraries
 Included Libraries
 ==================
 
+Competition Simulator
+---------------------
+
+The competition simulator currently doesn't include any packages other than the
+standard library. If there is library you would like included, please let us
+know [via the forums](/forum) and include a link to the package on
+[PyPI](https://pypi.org/).
+
+Robot Kit
+---------
+
 The following python libraries are installed and available for use in your robot's software:
 
  * [Babel 1.3.3](http://babel.pocoo.org/)


### PR DESCRIPTION
We've decided to allow the inclusion of libraries, so document a way that teams can request them.

See Slack conversation starting at https://studentrobotics.slack.com/archives/CD6C80TRD/p1592561812008400.