### PR TITLE
It turns out that Webots doesn't (yet) support Python 3.9

### DIFF
--- a/simulator/index.md
+++ b/simulator/index.md
@@ -22,9 +22,9 @@ You will also need Python installed.
 
 | Platform | Supported Python Version |
 |----------|--------------------------|
-| Windows  | >= 3.7 (64-bit)          |
-| macOS    | >= 3.7                   |
-| Linux    | >= 3.7                   |
+| Windows  | 3.7 - 3.8 (64-bit)       |
+| macOS    | 3.7 - 3.8                |
+| Linux    | 3.7 - 3.8                |
 
 In the competition, Python 3.7 will be used.
 


### PR DESCRIPTION
The current development version does, which is why the docs say that it's supported, however the latest release doesn't yet have that support.

See https://github.com/cyberbotics/webots/issues/2469.