### PR TITLE
Distance sensors don't work at extreme angles

### DIFF
--- a/simulator/programming/index.md
+++ b/simulator/programming/index.md
@@ -68,6 +68,7 @@ Analogous to ultrasound sensors, distance sensors allow you to retrieve the dist
 | 5   | Back Right |
 
 These are shown as blue coloured blocks on the robot. The `analogue_read` method will return the distance in metres, however only measure up to 30cm.
+Since these sensors rely on echoes being reflected back from objects, if the angle of incidence between the sensor's pulse and the contacted surface exceeds 22.5 degrees then the sensor will be unable to detect the object.
 
 #### LEDs
 


### PR DESCRIPTION
Sonar type distance sensor will only detect an object if the pulse contacts the face within a 45 degree cone about the normal.
See https://cyberbotics.com/doc/reference/distancesensor#sonar-sensors for more details.