### PR TITLE
Specify the version of webots used

### DIFF
--- a/simulator/index.md
+++ b/simulator/index.md
@@ -14,7 +14,7 @@ title: Simulator
 
 ### Prerequisites
 
-You need to download and install [Webots](https://cyberbotics.com/#download) (the download is around 1.5GB). This is the platform we run our simulation in.
+You need to download and install [Webots](https://cyberbotics.com/#download) (the download is around 1.5GB). This is the platform we run our simulation in. The simulator supports version "R2021a" of Webots, and will show warnings for incorrect versions.
 
 #### Python Version
 

--- a/simulator/index.md
+++ b/simulator/index.md
@@ -14,7 +14,7 @@ title: Simulator
 
 ### Prerequisites
 
-You need to download and install [Webots](https://cyberbotics.com/#download) (the download is around 1.5GB). This is the platform we run our simulation in. The simulator supports version "R2021a" of Webots, and will show warnings for incorrect versions.
+You need to download and install [Webots](https://cyberbotics.com/#download) (the download is around 1.5GB). This is the platform we run our simulation in. Whilst we recommend version "R2021a" of Webots, and will be running competition simulations using it, "R2020b-rev1" should still work.
 
 #### Python Version
 


### PR DESCRIPTION
Do not merge until module 3.

We're now changing the version requirement. It'll still work on older ones, but we want to encourage using new ones, as it fixes a number of issues.