### PR TITLE
Remove Shipping link from sidebar.yml

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -122,5 +122,3 @@ tree:
       title: Discord Server
     - url: /team_admin/user_accounts
       title: User Accounts
-    - url: /team_admin/kit_shipping
-      title: Kit Shipping

--- a/team_admin/index.md
+++ b/team_admin/index.md
@@ -6,4 +6,4 @@ title: Team Admin
 Team Admin
 ==========
 
-The pages in this section cover all of the non-competition related topics, such as [user management](/docs/team_admin/user_accounts) and [kit shipping](/docs/team_admin/kit_shipping).
+The pages in this section cover all of the non-competition related topics, such as [user management](/docs/team_admin/user_accounts).


### PR DESCRIPTION
The sidebar is manually configured and the link needs to be deleted from it manually