### PR TITLE
Add html-proofer as a validation mechanism

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,5 +25,5 @@ jobs:
         bundler-cache: true
         cache-version: 1
 
-    - name: Build
-      run: rake build
+    - name: Build & Validate
+      run: rake validate

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,8 @@ gem 'kramdown-parser-gfm'
 gem 'jekyll', 3.9
 gem 'jekyll-redirect-from'
 
+# For testing output
+gem 'html-proofer'
+
 # Avoid polling on windows
 gem 'wdm', '>= 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,21 @@ GEM
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.0)
     ffi (1.15.0-x64-mingw32)
     forwardable-extended (2.6.0)
+    html-proofer (3.19.2)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -44,12 +54,23 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.6.1)
     neat (3.0.0)
       sass (~> 3.4)
       thor (~> 0.19)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x64-mingw32)
+      racc (~> 1.4)
+    nokogumbo (2.0.5)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.21.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
+    racc (1.5.2)
+    rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -63,13 +84,17 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thor (0.20.3)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     wdm (0.1.1)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
   x64-mingw32
 
 DEPENDENCIES
+  html-proofer
   jekyll (= 3.9)
   jekyll-redirect-from
   kramdown

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,5 @@ task :validate => [:build] do
   # --empty-alt-ignore  # To avoid needing to fix lots upfront, we can migrate towards this later.
   # --allow-hash-href   # Allow empty `#` links to mean "top of page". It's true that these can be errors, however we have far too many to really address this.
   # --url-swap          # Adjust for Jekyll's baseurl. See https://github.com/gjtorikian/html-proofer/issues/618 for more.
-  # --url-ignore        # Allow mailto links without a target email, for our Share links. Works around https://github.com/gjtorikian/html-proofer/issues/552.
-  #                     # Allow old event links which aren't easily updated.
   sh('bundle exec htmlproofer _site --assume-extension --disable-external --empty-alt-ignore --allow-hash-href --url-swap "^/docs/:/"')
 end

--- a/Rakefile
+++ b/Rakefile
@@ -23,3 +23,15 @@ end
 task :build => [:dependencies, :submodules] do
   sh('bundle exec jekyll build --config _config.yml')
 end
+
+task :validate => [:build] do
+  # Explanation of arguments:
+  # --assume-extension  # Tells html-proofer that `.html` files can be accessed without the `.html` part in the url.
+  # --disable-external  # For speed. Ideally we'd check external links too, but ignoring for now.
+  # --empty-alt-ignore  # To avoid needing to fix lots upfront, we can migrate towards this later.
+  # --allow-hash-href   # Allow empty `#` links to mean "top of page". It's true that these can be errors, however we have far too many to really address this.
+  # --url-swap          # Adjust for Jekyll's baseurl. See https://github.com/gjtorikian/html-proofer/issues/618 for more.
+  # --url-ignore        # Allow mailto links without a target email, for our Share links. Works around https://github.com/gjtorikian/html-proofer/issues/552.
+  #                     # Allow old event links which aren't easily updated.
+  sh('bundle exec htmlproofer _site --assume-extension --disable-external --empty-alt-ignore --allow-hash-href --url-swap "^/docs/:/"')
+end

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,25 +3,25 @@
     <div class="column d-4-12 m-2-12">
       <h4>For Competitors</h4>
       <ul class="sitemap">
-        <li><a href="/teams/">Teams Dashboard</a></li>
-        <li><a href="/ide/">IDE</a></li>
-        <li><a href="/docs/">Documentation</a></li>
+        <li><a href="{{ site.url }}/teams/">Teams Dashboard</a></li>
+        <li><a href="{{ site.url }}/ide/">IDE</a></li>
+        <li><a href="{{ site.url }}/docs/">Documentation</a></li>
       </ul>
     </div>
     <div class="column d-4-12 m-2-12">
       <h4>Student Robotics</h4>
       <ul class="sitemap">
-        <li><a href="/compete/">Compete</a></li>
-        <li><a href="/volunteer/">Volunteer</a></li>
-        <li><a href="/sponsor/">Sponsor</a></li>
+        <li><a href="{{ site.url }}/compete/">Compete</a></li>
+        <li><a href="{{ site.url }}/volunteer/">Volunteer</a></li>
+        <li><a href="{{ site.url }}/sponsor/">Sponsor</a></li>
       </ul>
     </div>
     <div class="column d-4-12 m-2-12">
       <h4>&nbsp;</h4>
       <ul class="sitemap">
-        <li><a href="/blog/">Blog</a></li>
-        <li><a href="/events/">Events</a></li>
-        <li><a href="/contact/">Contact us</a></li>
+        <li><a href="{{ site.url }}/blog/">Blog</a></li>
+        <li><a href="{{ site.url }}/events/">Events</a></li>
+        <li><a href="{{ site.url }}/contact/">Contact us</a></li>
       </ul>
     </div>
   </div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,16 +6,16 @@
   </div>
   <ul id="navigation" class="full-navigation mobile-collapsed">
     <li>
-      <a class="page-link" href="/teams/">Teams</a>
+      <a class="page-link" href="{{ site.url }}/teams/">Teams</a>
     </li>
     <li>
-      <a class="page-link" href="/compete/">Compete</a>
+      <a class="page-link" href="{{ site.url }}/compete/">Compete</a>
     </li>
     <li>
-      <a class="page-link" href="/volunteer/">Volunteer</a>
+      <a class="page-link" href="{{ site.url }}/volunteer/">Volunteer</a>
     </li>
     <li>
-      <a class="page-link" href="/sponsor/">Sponsor</a>
+      <a class="page-link" href="{{ site.url }}/sponsor/">Sponsor</a>
     </li>
   </ul>
 </nav>

--- a/kit/wifi.md
+++ b/kit/wifi.md
@@ -27,7 +27,7 @@ Note that, because the information for your robot's WiFi network is stored insid
 the WiFi network will disappear when you unplug the USB memory stick. It will reappear a few moments
 after you plug the USB memory stick into your robot.
 
-If you are having any problems connecting to your robot, just head on over to the [forum](/forum)
+If you are having any problems connecting to your robot, just head on over to the [forum]({{ site.url }}/forum)
 and ask for help.
 
 Interacting With Your Robot

--- a/programming/python/index.md
+++ b/programming/python/index.md
@@ -26,4 +26,4 @@ There are a number of tutorials out there which might help you to learn to progr
     [Google's Python Class](https://developers.google.com/edu/python) looks to be a good tutorial which has some lecture videos to go with it.
 
 * [The Official Docs](https://docs.python.org/2.7/), for the version of python on the [Odroid Brain Boards](/docs/kit/brain_board).
-    We also host a [copy](/docs/python) of docs for the precise version (2.7.5) that it uses.
+    We also host a [copy]({{ site.url }}/docs/python) of docs for the precise version (2.7.5) that it uses.

--- a/programming/python/libraries.md
+++ b/programming/python/libraries.md
@@ -22,7 +22,7 @@ yourself.
  * [scipy 1.5.4](https://pypi.org/project/scipy/1.5.4/)
 
 If there are other libraries you would like included, please let us know
-[via the forums](/forum) and include a link to the package on [PyPI](https://pypi.org/).
+[via the forums]({{ site.url }}/forum) and include a link to the package on [PyPI](https://pypi.org/).
 
 Robot Kit
 ---------

--- a/team_admin/user_accounts.md
+++ b/team_admin/user_accounts.md
@@ -7,8 +7,8 @@ title: User Accounts
 # User Accounts
 
 Your User Account can be used to access the various online services that we host.
-These include the [forums](/forum), [IDE](/ide) and, for team-leaders,
-a [user management interface](/userman) (see [below](#UserManagement)).
+These include the [forums]({{ site.url }}/forum), [IDE]({{ site.url }}/ide) and, for team-leaders,
+a [user management interface][userman] (see [below](#UserManagement)).
 
 ### Getting an Account
 If you don't yet have an account, you should contact your team-leader,
@@ -34,7 +34,7 @@ They will be able to tell you the details of your account, or reset your passwor
 
 ### Password Change
 If you know your password, but want to change it,
-you can do this using the self service side of the [user management page](/userman).
+you can do this using the self service side of the [user management page][userman].
 
 ### Other Problems
 If your team-leader was unable to resolve your account issue,
@@ -45,7 +45,7 @@ you can ask them to email <{{ site.emails.accounts }}> for more help.
 
 ### Account creation
 
-To create user accounts, visit the [user management page](/userman), and
+To create user accounts, visit the [user management page][userman], and
 log in. In a column on the left, you'll see a list of users currently
 registered for your team.  At the bottom is a link marked 'Register users'.
 Click on this, and you'll be presented with a form for user details.
@@ -67,7 +67,7 @@ When an account is created it starts off as a competitor account. In order to
 allow your fellow team leaders to have full access to the user management pages
 (among other things), you should change them to being a team leader account.
 
-You can change the type of an account in the [user management page](/userman):
+You can change the type of an account in the [user management page][userman]:
 
 1. Select the user in question from the list on the left hand side
 1. Under 'Type' change the selection to 'Team Leader'
@@ -78,7 +78,7 @@ Feel free to add as many team leader accounts as you like; there's no upper limi
 ### Account maintenance
 
 If you need to update any user account data, find their username,
-reset their password or so forth, first log into the [user management page](/userman).
+reset their password or so forth, first log into the [user management page][userman].
 
 Once there, you should find the users name in the list of registered
 users on the left, as well as their username. To check or update their details,
@@ -94,3 +94,5 @@ forget passwords, please find their account as described above and click the
 a single-use link to reset their password.
 
 If you forget your own password, please contact <{{ site.emails.accounts }}>.
+
+[userman]: {{ site.url }}/userman/

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -9,7 +9,7 @@ Troubleshooting
 If you are experiencing problems with either the Student Robotics hardware,
 IDE or python library you should check here first to see if there is a simple solution.
 If you don't find the information you need in this section you can use the
-[forum](/forum/) to get help with your specific problem.
+[forum]({{ site.url }}/forum/) to get help with your specific problem.
 
 1. [`sr.robot` python library issues](/docs/troubleshooting/python) &mdash; Common problems with the `sr.robot` python library and possible solutions.
 2. [Interactive Troubleshooter](/docs/troubleshooting/interactive_troubleshooter) &mdash; Consider using the Interactive Troubleshooter to narrow down your problem and find a solution.
@@ -59,5 +59,5 @@ Check the docs
     and then forget something out of familiarity.
 
     By double-checking the appropriate docs (be it for the [kit](/docs/kit),
-    for [Python](/docs/python) or for the extra thing you've bought) you
-    can be completely sure that you've not missed something.
+    for [Python]({{ site.url }}/docs/python) or for the extra thing you've bought)
+    you can be completely sure that you've not missed something.

--- a/tutorials/python.md
+++ b/tutorials/python.md
@@ -714,7 +714,7 @@ print((x == 2 and y == 3) or z == 2)
 ~~~~~
 
 
-[Built-in functions](#built-in-function) {#built-in-functions}
+[Built-in functions](#built-in-functions) {#built-in-functions}
 --------------------
 
 A lot of functions are defined for you by Python. Those listed at <https://docs.python.org/library/functions.html> are always available, and are the most commonly used, including `len`, `range`, and enumerate.


### PR DESCRIPTION
Contributes towards https://github.com/srobo/tasks/issues/701.

Contrary to https://github.com/srobo/website/pull/318, I've used `{{ site.url }}` rather than our literal domain name. This feels like it might be slightly nicer here, though there is some room for confusion between it and `{{ site.baseurl }}`. Would be good to get feedback on this -- if it's preferred I'll update the website repo to do the same.