### PR TITLE
Kit details from rules

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -27,6 +27,8 @@ tree:
       title: Servo Board
     - url: /kit/wifi
       title: WiFi
+    - url: /kit/safety-regulations
+      title: Safety Regulations
   - url: /programming/
     title: Programming
     tree:

--- a/kit/index.md
+++ b/kit/index.md
@@ -40,11 +40,8 @@ As well as the aforementioned boards the kit also contains the following items.
 | USB Memory Stick       | 1   | Kingston Datatraveler 16GB SE9H                                       | [DTSE9H/16GB][DTSE9H-16GB]                  |
 | Standard USB cable     | 3   | Standard USB A to B connector                                         | N/A                                         | For connecting the ruggeduino (via a hub) and USB hubs to the ODROID
 | Micro USB cable        | 5   | Standard USB A to Micro USB B                                         | N/A                                         | For connecting the motor boards, servo boards and power board to the ODROID
-| Blue Hook-up Wire      | 1   | 2.5m<br />0.5mm<sup>2</sup><br />4A                                   | [RS 361-585][RS-361-585]                    | General purpose wire
-| Yellow Hook-up Wire    | 1   | 2.5m<br />0.5mm<sup>2</sup><br />4A                                   | [RS 361-636][RS-361-636]                    | General purpose wire
-| Green Power Wire       | 1   | 2.5m<br />1mm<sup>2</sup><br />10A                                    | [RS 748-2042][RS-748-2042]                  | To connect the motors to the motor boards only
-| Red Power Wire         | 1   | 2.5m<br />1mm<sup>2</sup><br />10A                                    | [RS 361-759][RS-361-759]                    | To connect power from the power board to the motor/servo boards
-| Black Power Wire       | 1   | 2.5m<br />1mm<sup>2</sup><br />10A                                    | [RS 361-715][RS-361-715]                    | To connect power from the power board to the motor/servo boards
+| Coloured Power Wire    | 1   |                                                                       |                                             | To connect power from the power board to the motor/servo boards
+| Black Power Wire       | 1   |                                                                       |                                             | To connect power from the power board to the motor/servo boards
 | CamCon                 | 10  | 2 way<br />7.5mm<br />12A                                             | [Farnell 3882275][F-3882275]                | To connect 12V from the power board to the motor and servo boards
 | MiniCamCon             | 7   | 2 way<br />5mm<br />12A                                               | [Farnell 3881854][F-3881854]                | To connect motors to the motor boards, and to connect an external power switch
 | MicroCamCon            | 1   | 2 way<br />3.81mm<br />12A                                            | [Farnell 1717047][F-1717047]                | To connect a 5V component to the power board or to connect an external start button
@@ -60,11 +57,7 @@ As well as the aforementioned boards the kit also contains the following items.
 [F-3881854]: https://uk.farnell.com/3881854
 [F-1717047]: https://uk.farnell.com/1717047
 [F-2103271]: https://uk.farnell.com/2103271
-[RS-361-715]: https://uk.rs-online.com/web/p/products/361-715
-[RS-361-759]: https://uk.rs-online.com/web/p/products/361-759
 [RS-748-2042]: https://uk.rs-online.com/web/p/products/748-2042
-[RS-361-585]: https://uk.rs-online.com/web/p/products/361-585
-[RS-361-636]: https://uk.rs-online.com/web/p/products/361-636
 [EB-230435]: https://www.ebuyer.com/230435-logitech-c270-hd-webcam-720p-hd-video-960-000582
 [G138960965859]: https://www.hardkernel.com/main/products/prdt_info.php?g_code=G138960965859
 [0000153]: https://www.modelsport.co.uk/overlander-lipo-safe-sack/rc-car-products/38313

--- a/kit/safety-regulations.md
+++ b/kit/safety-regulations.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Safety Regulations
+---
+
+# Safety Regulations
+
+To maintain safety at the competition, all robots at the event are required to pass the safety regulations that are listed below. Robots that do not comply to these rules will not be permitted to compete.
+
+These regulations are intended to identify a base level of safety — the inspector will use their own judgement and common sense when assessing your robot, and your robot may be judged to be unsafe for reasons or features not listed here.
+
+We recommend that you bear these regulations in mind during development too, although it’s not always possible to meet them while building and testing your robot.
+
+The following procedure will be used when testing a robot:
+- Check that there is a battery installed in the robot.
+- Check that any additional power sources have already been authorised.
+- Check that the battery cable originally provided by Student Robotics is being used to connect the power board to the battery. If not, check that the replacement has suitable rating and quality.
+- Leaving the battery physically installed, unplug the deans connector.
+- Check the battery’s mounting holds the battery securely, and does not expose the battery to sharp edges.
+- Check that the battery’s casing is rigid, and strong – i.e. bubble wrap is not suitable.
+- Locate the large green power connector that connects the battery to the power board. In turn, give each of the wires that enter it a gentle tug. The cables must not move.
+- Check that there is not an excessive amount of unshielded wire protruding from the large green power connector.
+- Check that the cable between the large green power connector and the deans connector is not damaged. The sheath must not have any holes in etc.
+- Check that the cables between the power board and body of the battery do not pass through areas of the robot that could cause them to be damaged by moving mechanical parts.
+- Check that only the power board is connected to the battery (if the deans connector were currently connected).
+- Check that the power switch on the power board is easily accessible.
+- Check that all electronics are securely fixed to the robot.
+- Check for unreasonably sharp edges and dangerous moving parts.


### PR DESCRIPTION
Move some of the details usually put in the appendices of the rules into the docs, where it's easier to reference. 

See https://studentrobotics.org/docs/resources/2019/rulebook.pdf

This is mostly useful for the kit disclaimer forms, so we can reference these bits of documentation without releasing a full rulebook.