### PR TITLE
Remove mentions of WiFi that isn't shipping (yet)

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -25,8 +25,6 @@ tree:
       title: Ruggeduino
     - url: /kit/servo_board
       title: Servo Board
-    - url: /kit/wifi
-      title: WiFi
     - url: /kit/safety-regulations
       title: Safety Regulations
   - url: /programming/

--- a/kit/index.md
+++ b/kit/index.md
@@ -21,11 +21,6 @@ The boards provided are as follows; more details can be found on their individua
  * [Ruggeduino (including two screw shields)](/docs/kit/ruggeduino)
  * [Servo Board](/docs/kit/servo_board)
 
-The WiFi
--------------------
-
-The kit can be controlled over [WiFi](/docs/kit/wifi). You can use any device to connect to the WiFi.
-
 Ancillary Parts
 ---------------
 

--- a/kit/power_board.md
+++ b/kit/power_board.md
@@ -65,7 +65,7 @@ Controls
 | Control        | Use
 |----------------|----------------------------
 | ON\|OFF        | Turns the power board on, when used in conjunction with an external switch
-| START          | Starts your program (can be used instead of the robot WiFi interface)
+| START          | Starts your program
 
 
 Case Dimensions

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -36,9 +36,8 @@ Explain it to someone else
 
 Check the log file for errors
 :   If your program has an error in it, it will stop running or not run at all.
-    Check [the log file](/docs/troubleshooting/python#ReadingTheLogs) either through the
-    robot [WiFi](/docs/kit/wifi) interface or look at the log file on the USB stick to
-    see any error reports.
+    Check [the log file](/docs/troubleshooting/python#ReadingTheLogs) on the USB
+    stick to see any error reports.
 
 Print all the things
 :   Adding `print` statements
@@ -50,8 +49,7 @@ Print all the things
 
     On the robots the output from any `print` statements will end up
     in [the log file](/docs/troubleshooting/python#ReadingTheLogs), which can
-    be viewed either in the robot [WiFi](/docs/kit/wifi) interface or on
-    the USB stick.
+    be viewed on the USB stick.
 
 Check the docs
 :   It's very easy to end up thinking that you know how something works

--- a/troubleshooting/python.md
+++ b/troubleshooting/python.md
@@ -13,9 +13,7 @@ If you encounter one that isn't on this list, quickly check your code and search
 ## [Reading the Logs](#ReadingTheLogs) {#ReadingTheLogs}
 
 When your program runs on the robot, the output of `print` statements and any
-errors which occur are written to a log file. You can view this log file via the
-robot [WiFi](/docs/kit/wifi) interface (by touching the menu icon in the
-top-left, followed by "Logs"). It is also written to the USB stick as `log.txt`.
+errors which occur are written to a log file on the USB stick as `log.txt`.
 
 ## [Syntax Error](#SyntaxError) {#SyntaxError}
 


### PR DESCRIPTION
We're not shipping WiFi yet, so remove mentions of it from the docs.
This leaves the dedicated WiFi page, but hides it from the sidebar. All the other mentions are removed. Hopefully this should be easy enough to revert when the WiFi does ship.