### PR TITLE
Override paragraph styling inside message boxes

### DIFF
--- a/_sass/messages.scss
+++ b/_sass/messages.scss
@@ -14,6 +14,8 @@ $error: #BF433A;
   color: $info;
 
   p {
+    // Prevent our custom styles being overwritten if a div
+    // has markdownenabled="1"
     color: $info;
   }
 }
@@ -25,6 +27,8 @@ $error: #BF433A;
   color: $error;
 
   p {
+    // Prevent our custom styles being overwritten if a div
+    // has markdownenabled="1"
     color: $error;
   }
 }

--- a/_sass/messages.scss
+++ b/_sass/messages.scss
@@ -17,6 +17,7 @@ $error: #BF433A;
     // Prevent our custom styles being overwritten if a div
     // has markdownenabled="1"
     color: $info;
+    margin: unset;
   }
 }
 
@@ -30,5 +31,6 @@ $error: #BF433A;
     // Prevent our custom styles being overwritten if a div
     // has markdownenabled="1"
     color: $error;
+    margin: unset;
   }
 }

--- a/_sass/messages.scss
+++ b/_sass/messages.scss
@@ -17,7 +17,8 @@ $error: #BF433A;
     // Prevent our custom styles being overwritten if a div
     // has markdownenabled="1"
     color: $info;
-    margin: unset;
+    margin: 0;
+    font-size: 1rem;
   }
 }
 
@@ -31,6 +32,7 @@ $error: #BF433A;
     // Prevent our custom styles being overwritten if a div
     // has markdownenabled="1"
     color: $error;
-    margin: unset;
+    margin: 0;
+    font-size: 1rem;
   }
 }

--- a/_sass/messages.scss
+++ b/_sass/messages.scss
@@ -12,6 +12,10 @@ $error: #BF433A;
   background: transparentize($info, 0.8);
   border-color: $info;
   color: $info;
+
+  p {
+    color: $info;
+  }
 }
 
 .warning {
@@ -19,4 +23,8 @@ $error: #BF433A;
   background: transparentize($error, 0.8);
   border-color: $error;
   color: $error;
+
+  p {
+    color: $error;
+  }
 }


### PR DESCRIPTION
Content within a div that has markdown enabled is wrapped in a p tag which means our custom styles were overwritten.

Fixes #279 