### PR TITLE
Validate sidebar & kit version data

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ task :validate_links => [:build] do
   sh('bundle exec htmlproofer _site --assume-extension --disable-external --empty-alt-ignore --allow-hash-href --url-swap "^/docs/:/"')
 end
 
-task :validate_sidebar_tree do # => [:build] do
+task :validate_sidebar_tree => [:build] do
   # There are lots of things which this could validate, however we assume that
   # most changes will be eyeballed by a human. We therefore just check the most
   # nuanced case -- that the url must be an exact match for its target page.

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,8 @@ task :validate_kit_versions do
     messages << "Extra keys: #{extra.to_a.join(', ')}" if extra.size() > 0
     raise "For entry\n#{entry}\n#{messages.join("\n")}\n\n" if messages.size() > 0
   end
+
+  puts "Kit versions validated successfully"
 end
 
 task :validate_links => [:build] do

--- a/Rakefile
+++ b/Rakefile
@@ -59,9 +59,11 @@ task :validate_sidebar_tree => [:build] do
 
   def check_url(url)
     if url.end_with?("/") then
-      raise "Imprecise target url '#{url}' in sidebar (did you mean '#{url[..-2]}'?)\n\n" unless File.directory?("_site#{url}")
+      return if File.directory?("_site#{url}")
+      raise "Imprecise target url '#{url}' in sidebar (did you mean '#{url[..-2]}'?)\n\n"
     else
-      raise "Imprecise target url '#{url}' in sidebar (did you mean '#{url}/'?)\n\n" unless File.file?("_site#{url}.html")
+      return if File.file?("_site#{url}.html")
+      raise "Imprecise target url '#{url}' in sidebar (did you mean '#{url}/'?)\n\n"
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ task :validate_sidebar_tree => [:build] do
   # nuanced case -- that the url must be an exact match for its target page.
 
   def check_url(url)
-    if url.end_with? "/" then
+    if url.end_with?("/") then
       raise "Imprecise target url '#{url}' in sidebar (did you mean '#{url[..-2]}'?)\n\n" unless File.directory?("_site#{url}")
     else
       raise "Imprecise target url '#{url}' in sidebar (did you mean '#{url}/'?)\n\n" unless File.file?("_site#{url}.html")

--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -63,7 +63,7 @@ tree:
         tree:
         - url: /programming/sr/vision/markers
           title: Markers
-    - url: /programming/editors
+    - url: /programming/editors/
       title: Code Editors
       tree:
       - url: /programming/editors/vscode


### PR DESCRIPTION
Fixes https://github.com/srobo/docs/issues/294.

This adds validation that the sidebar urls and kit versions are in the right formats.
The validation for the sidebar urls focusses more on the things which are harder to spot as the chances of making an accidental change which breaks the sidebar without noticing are fairly high.