### PR TITLE
Update the current Ruggeduino FW_VER to1

### DIFF
--- a/resources/kit/ruggeduino-fw.ino
+++ b/resources/kit/ruggeduino-fw.ino
@@ -3,7 +3,7 @@
 // We communicate with the power board at 115200 baud.
 #define SERIAL_BAUD 115200
 
-#define FW_VER 0
+#define FW_VER 1
 
 void setup() {
   Serial.begin(SERIAL_BAUD);


### PR DESCRIPTION
In order to match the version that we flash to boards, this should be `1`.

This needs to be changed as the latest version of the kit software actually verifies that the firmware versions are supported before proceeding.