### PR TITLE
Update ruggeduino firmware version to match the default

### DIFF
--- a/resources/kit/ruggeduino-fw.ino
+++ b/resources/kit/ruggeduino-fw.ino
@@ -3,7 +3,7 @@
 // We communicate with the power board at 115200 baud.
 #define SERIAL_BAUD 115200
 
-#define FW_VER 0
+#define FW_VER 1
 
 void setup() {
   Serial.begin(SERIAL_BAUD);


### PR DESCRIPTION
The firmware version is no longer used to differentiate stock and extended firmwares so keeping this in step with the stock firmware allows us to keep track of the starting versions of extended firmwares.