### PR TITLE
Link to historic ruggeduino docs

### DIFF
--- a/kit/ruggeduino.md
+++ b/kit/ruggeduino.md
@@ -58,5 +58,5 @@ when using the Ruggeduino to drive the LED a current limiting resistor is not re
 
 ## Design
 
-* [Schematic](http://ruggedcircuits.com/AM010/am010.pdf)
-* [Manufacturer's documentation](http://ruggedcircuits.com/html/ruggeduino.html)
+* [Schematic](https://web.archive.org/web/20140210003143/http://ruggedcircuits.com/AM010/am010.pdf)
+* [Manufacturer's documentation](https://web.archive.org/web/20170317171649/https://www.rugged-circuits.com/ruggeduino)


### PR DESCRIPTION
This updates the links to use versions hosted by the internet archive as the original manufacturer no longer hosts these pages.

I _think_ the internet archive allows this; I had a quick skim of their terms of service and couldn't see anything otherwise (searches for "link" didn't highlight anything).

Fix https://github.com/srobo/docs/issues/113.