### PR TITLE
Add clarification of 'spherical' variables

### DIFF
--- a/programming/sr/vision/index.md
+++ b/programming/sr/vision/index.md
@@ -224,12 +224,12 @@ The spherical coordinates system has three values to specify a specific point in
 - φ (phi) - The polar angle from the plane of the camera to the point, in radians.
 
 rot_x
-:   Rotation around the X-axis, in radians.
+:   Rotation around the X-axis, in radians, corresponding to `theta` on the diagram.
 
 rot_y
-:   Rotation around the Y-axis, in radians.
+:   Rotation around the Y-axis, in radians, corresponding to `phi` on the diagram.
 
 dist
-:   Distance, in metres.
+:   Distance, in metres, corresponding to `r` on the diagram.
 
 The camera is located at the origin, where the coordinates are (0, 0, 0).


### PR DESCRIPTION
It's not currently clear how the diagram maps to the variables; this pull request changes that.