### PR TITLE
Fix link to the ThreeDCoordinate section

### DIFF
--- a/programming/sr/vision/index.md
+++ b/programming/sr/vision/index.md
@@ -157,7 +157,7 @@ spherical
 :   A [`Spherical`](#Spherical) instance describing the position relative to the camera.
 
 cartesian
-:   A [`ThreeDCoordinates`][#ThreeDCoordinates] instance describing the absolute position of the marker relative to the camera.
+:   A [`ThreeDCoordinate`](#ThreeDCoordinate) instance describing the absolute position of the marker relative to the camera.
 
 [`Coordinate`](#Coordinate) {#Coordinate}
 ---------


### PR DESCRIPTION
The naming of these objects also seems somewhat confusing -- _lots_ of these are three dimensional coordinates, so the one called `ThreeDCoordinate` should probably be called `CartesianCoordinate`, since that's what it actually is. Obviously that's an API change rather than something we can do now.