### PR TITLE
Fix Safety Regulations

### DIFF
--- a/kit/safety-regulations.md
+++ b/kit/safety-regulations.md
@@ -12,17 +12,59 @@ These regulations are intended to identify a base level of safety — the inspec
 We recommend that you bear these regulations in mind during development too, although it’s not always possible to meet them while building and testing your robot.
 
 The following procedure will be used when testing a robot:
-- Check that there is a battery installed in the robot.
-- Check that any additional power sources have already been authorised.
-- Check that the battery cable originally provided by Student Robotics is being used to connect the power board to the battery. If not, check that the replacement has suitable rating and quality.
-- Leaving the battery physically installed, unplug the deans connector.
-- Check the battery’s mounting holds the battery securely, and does not expose the battery to sharp edges.
-- Check that the battery’s casing is rigid, and strong – i.e. bubble wrap is not suitable.
-- Locate the large green power connector that connects the battery to the power board. In turn, give each of the wires that enter it a gentle tug. The cables must not move.
-- Check that there is not an excessive amount of unshielded wire protruding from the large green power connector.
-- Check that the cable between the large green power connector and the deans connector is not damaged. The sheath must not have any holes in etc.
-- Check that the cables between the power board and body of the battery do not pass through areas of the robot that could cause them to be damaged by moving mechanical parts.
-- Check that only the power board is connected to the battery (if the deans connector were currently connected).
-- Check that the power switch on the power board is easily accessible.
-- Check that all electronics are securely fixed to the robot.
-- Check for unreasonably sharp edges and dangerous moving parts.
+
+1. Check that the parts of the robot that were provided by Student
+   Robotics are in a safe condition. If any of the following criteria
+   are not met, the offending component must be replaced with one in
+   suitable condition, and the procedure restarted from the beginning.
+
+    1. Check that the cables between the power board and body of the
+       battery are not damaged. The sheath must not have any holes in
+       it.
+
+    2. Locate the yellow XT60 connector pair that joins the battery to
+       the cable leading back to the power board. Check that the
+       insulation surrounding these connectors and the attached wiring
+       is undamaged.
+
+    3. In turn, give each of the wires attached to these connectors a
+       gentle tug. The cables must not move relative to the connectors.
+
+    4. Locate the metal terminals that connect the battery cable to the
+       power board. Check that the insulation surrounding these
+       terminals and the attached wiring is undamaged.
+
+    5. In turn, give each of the wires attached to these terminals a
+       gentle tug. The cables must not move.
+
+2. Check that the parts of the robot that were built by the competitors
+    are in a safe condition. If any of the following criteria are not
+    met, the team must be instructed to make amendments to the robot.
+
+    1. Check that there is a battery installed in the robot.
+
+    2. Check that any additional power sources have already been
+       authorised.
+
+    3. Leaving the battery physically installed, unplug the XT60
+       connector.
+
+    4. Check the battery's mounting holds the battery securely, and
+       does not expose the battery to sharp edges.
+
+    5. Check that the battery's casing is rigid, and strong -- i.e.
+       bubble wrap is not suitable.
+
+    6. Check that the cables between the power board and body of the
+       battery do not pass through areas of the robot that could cause
+       them to be damaged by moving mechanical parts.
+
+    7. Check that only the power board is connected to the battery (if
+       the XT60 connector were currently connected).
+
+    8. Check that the power switch on the power board is easily
+       accessible.
+
+    9. Check that all electronics are securely fixed to the robot.
+
+    10. Check for unreasonably sharp edges and dangerous moving parts.

--- a/kit/safety-regulations.md
+++ b/kit/safety-regulations.md
@@ -63,7 +63,8 @@ The following procedure will be used when testing a robot:
        the XT60 connector were currently connected).
 
     8. Check that the power switch on the power board is easily
-       accessible.
+       accessible. This must be on the exterior of the robot, not
+       behind any covers and ideally on the top.
 
     9. Check that all electronics are securely fixed to the robot.
 

--- a/kit/safety-regulations.md
+++ b/kit/safety-regulations.md
@@ -69,3 +69,9 @@ The following procedure will be used when testing a robot:
     9. Check that all electronics are securely fixed to the robot.
 
     10. Check for unreasonably sharp edges and dangerous moving parts.
+
+    11. Check that there is not an excessive amount of unshielded wire
+        protruding from any of the green CamCon connectors.
+
+    12. In turn, give each of the wires attached to the green CamCon
+        connectors a gentle tug. The cables must not move.

--- a/kit/safety-regulations.md
+++ b/kit/safety-regulations.md
@@ -17,61 +17,44 @@ The following procedure will be used when testing a robot:
    Robotics are in a safe condition. If any of the following criteria
    are not met, the offending component must be replaced with one in
    suitable condition, and the procedure restarted from the beginning.
-
     1. Check that the cables between the power board and body of the
        battery are not damaged. The sheath must not have any holes in
        it.
-
     2. Locate the yellow XT60 connector pair that joins the battery to
        the cable leading back to the power board. Check that the
        insulation surrounding these connectors and the attached wiring
        is undamaged.
-
     3. In turn, give each of the wires attached to these connectors a
        gentle tug. The cables must not move relative to the connectors.
-
     4. Locate the metal terminals that connect the battery cable to the
        power board. Check that the insulation surrounding these
        terminals and the attached wiring is undamaged.
-
     5. In turn, give each of the wires attached to these terminals a
        gentle tug. The cables must not move.
 
 2. Check that the parts of the robot that were built by the competitors
     are in a safe condition. If any of the following criteria are not
     met, the team must be instructed to make amendments to the robot.
-
     1. Check that there is a battery installed in the robot.
-
     2. Check that any additional power sources have already been
        authorised.
-
     3. Leaving the battery physically installed, unplug the XT60
        connector.
-
     4. Check the battery's mounting holds the battery securely, and
        does not expose the battery to sharp edges.
-
     5. Check that the battery's casing is rigid, and strong -- i.e.
        bubble wrap is not suitable.
-
     6. Check that the cables between the power board and body of the
        battery do not pass through areas of the robot that could cause
        them to be damaged by moving mechanical parts.
-
     7. Check that only the power board is connected to the battery (if
        the XT60 connector were currently connected).
-
     8. Check that the power switch on the power board is easily
        accessible. This must be on the exterior of the robot, not
        behind any covers and ideally on the top.
-
     9. Check that all electronics are securely fixed to the robot.
-
     10. Check for unreasonably sharp edges and dangerous moving parts.
-
     11. Check that there is not an excessive amount of unshielded wire
         protruding from any of the green CamCon connectors.
-
     12. In turn, give each of the wires attached to the green CamCon
         connectors a gentle tug. The cables must not move.


### PR DESCRIPTION
This fixes https://github.com/srobo/docs/issues/324 by copying in the regulations from the last version of the published rules prior to the move to HTML format. This therefore post-dates the changes to the kit with which the current regulations are incompatible with (surprising an issue which appears to have already been present but missed in https://github.com/srobo/docs/pull/256) but pre-dates the removal of the regulations from the rulebook.

The first commit here is a pure copy of the text from the rules, specifically as they were in the [SR2020.5](https://github.com/srobo/rules/releases/tag/SR2020.5) (https://github.com/srobo/rules/commit/00e4ede22f21b2c8e99d5aa5928fe60b4e1d2cad), converted with `pandoc`.

The second change clarifies the placement of the power switch, something which I had thought we'd introduced after having to turn teams away from the arena a number of times due to issues with.

The third change extends checking the safety of power delivery cables to those which competitors have made as well as those provided as part of the kit.

I suspect there are other things that should be checked too and likely these will want review by @Scarzy with a Health & Safety hat on, however it would be good to get this shipped promptly as the current regulations are somewhat confusing (given the mismatches with the kit) and there is not a huge amount of time until the competition.