### PR TITLE
Update kit list for SR2023

### DIFF
--- a/kit/index.md
+++ b/kit/index.md
@@ -33,15 +33,14 @@ As well as the aforementioned boards the kit also contains the following items.
 | USB Hub                | 2   | 7-Port                                                                | [StarTech ST7202USBGB][ST7202USBGB]         | The hub does *not* require a power cable
 | USB WiFi Adapter       | 1   | 300Mbps Mini Wireless N USB Adapter                                   | [TP-Link TL-WN823N][TL-WN823N]              |
 | USB Memory Stick       | 1   | Kingston Datatraveler 16GB SE9H                                       | [DTSE9H/16GB][DTSE9H-16GB]                  |
-| Standard USB cable     | 3   | Standard USB A to B connector                                         | N/A                                         | For connecting the ruggeduino (via a hub) and USB hubs to the ODROID
-| Micro USB cable        | 5   | Standard USB A to Micro USB B                                         | N/A                                         | For connecting the motor boards, servo boards and power board to the ODROID
+| Standard USB cable     | 3   | Standard USB A to B connector                                         | N/A                                         | For connecting the ruggeduino (via a hub) and USB hubs to the Brain Board
+| Micro USB cable        | 5   | Standard USB A to Micro USB B                                         | N/A                                         | For connecting the motor boards, servo boards and power board to the Brain Board
 | Coloured Power Wire    | 1   |                                                                       |                                             | To connect power from the power board to the motor/servo boards
 | Black Power Wire       | 1   |                                                                       |                                             | To connect power from the power board to the motor/servo boards
 | CamCon                 | 10  | 2 way<br />7.5mm<br />12A                                             | [Farnell 3882275][F-3882275]                | To connect 12V from the power board to the motor and servo boards
 | MiniCamCon             | 7   | 2 way<br />5mm<br />12A                                               | [Farnell 3881854][F-3881854]                | To connect motors to the motor boards, and to connect an external power switch
 | MicroCamCon            | 1   | 2 way<br />3.81mm<br />12A                                            | [Farnell 1717047][F-1717047]                | To connect a 5V component to the power board or to connect an external start button
 | USB Webcam             | 1   | Either Logitech C500 or Logitech C270                                 | [Ebuyer 230435][EB-230435]                  |
-| ODROID Power Cable     | 1   | DC Plug and Cable Assembly with MicroCamCon                           | [G138960965859][G138960965859]              |
 | Battery (LiPo)         | 2   | 11.1V 2.2Ah Lithium Polymer                                           | N/A                                         | Please read the [documentation](/docs/kit/batteries) for storage and usage information
 | Battery Bag            | 1   | HPI Plazma Pouch Lipo Safe Bag (18x22cm) or Overlander Lipo Safe Sack | [HPI 101289][HPI-101289] [0000153][0000153] | Batteries should always be stored in the battery bag
 | Screwdriver            | 1   | Duratool Precision 2.5mm Slot Screwdriver                             | [Farnell 2103271][F-2103271]                |
@@ -54,7 +53,6 @@ As well as the aforementioned boards the kit also contains the following items.
 [F-2103271]: https://uk.farnell.com/2103271
 [RS-748-2042]: https://uk.rs-online.com/web/p/products/748-2042
 [EB-230435]: https://www.ebuyer.com/230435-logitech-c270-hd-webcam-720p-hd-video-960-000582
-[G138960965859]: https://www.hardkernel.com/main/products/prdt_info.php?g_code=G138960965859
 [0000153]: https://www.modelsport.co.uk/overlander-lipo-safe-sack/rc-car-products/38313
 [HPI-101289]: https://www.modelsport.co.uk/hpi-plazma-pouch-lipo-safe-bag-18x22cm-/rc-car-products/39499
 [DTSE9H-16GB]: https://www.amazon.co.uk/dp/B006YBARCA

--- a/kit/index.md
+++ b/kit/index.md
@@ -31,7 +31,6 @@ As well as the aforementioned boards the kit also contains the following items.
 | Battery Charger Supply | 1   | 12V 5A                                                                | N/A                                         |
 | Battery Charger        | 1   | iMAX B6 or HobbyKing E4                                               | N/A                                         | Documentation is available on [charging the batteries](/docs/kit/batteries) using this
 | USB Hub                | 2   | 7-Port                                                                | [StarTech ST7202USBGB][ST7202USBGB]         | The hub does *not* require a power cable
-| USB WiFi Adapter       | 1   | 300Mbps Mini Wireless N USB Adapter                                   | [TP-Link TL-WN823N][TL-WN823N]              |
 | USB Memory Stick       | 1   | Kingston Datatraveler 16GB SE9H                                       | [DTSE9H/16GB][DTSE9H-16GB]                  |
 | Standard USB cable     | 3   | Standard USB A to B connector                                         | N/A                                         | For connecting the ruggeduino (via a hub) and USB hubs to the Brain Board
 | Micro USB cable        | 5   | Standard USB A to Micro USB B                                         | N/A                                         | For connecting the motor boards, servo boards and power board to the Brain Board
@@ -46,7 +45,6 @@ As well as the aforementioned boards the kit also contains the following items.
 | Screwdriver            | 1   | Duratool Precision 2.5mm Slot Screwdriver                             | [Farnell 2103271][F-2103271]                |
 
 [ST7202USBGB]: https://uk.startech.com/Cards-Adapters/USB-2/Hub/7-Port-USB-20-Hub-UK~ST7202USBGB
-[TL-WN823N]: https://www.tp-link.com/en/products/details/?model=TL-WN823N
 [F-3882275]: https://uk.farnell.com/3882275
 [F-3881854]: https://uk.farnell.com/3881854
 [F-1717047]: https://uk.farnell.com/1717047


### PR DESCRIPTION
Notably:

- Remove odroid power cable
- Remove references to odroid

Notably, we're not shipping any additional camcons for the KCH - there are enough with the current number.

This doesn't document or note the KCH - that'll happen later.