### PR TITLE
Get Brain Updates page ready for SR2023

### DIFF
--- a/_data/kit_versions.yml
+++ b/_data/kit_versions.yml
@@ -1,11 +1,2 @@
 # The latest version should be the first in this file.
-- version: 2022.2.0
-  released: 2022-04-18
-- version: 2022.1.0
-  released: 2022-02-04
-- version: 2022.0.2
-  released: 2021-11-23
-- version: 2022.0.1
-  released: 2021-11-20
-- version: 2022.0.0
-  released: 2021-11-13
+[]

--- a/_data/kit_versions.yml
+++ b/_data/kit_versions.yml
@@ -1,2 +1,5 @@
 # The latest version should be the first in this file.
+# The format of this file should be like such:
+# - version: 20xx.y.z
+#   released: 2038-01-19
 []

--- a/_includes/updates-table.html
+++ b/_includes/updates-table.html
@@ -17,7 +17,7 @@
       </td>
       <td>{{ kit_version.released | date_to_string }}</td>
       <td>
-        <a class="kit-download-link" data-version="{{ version }}" href="https://kit-downloads.studentrobotics.org/kit-software/{{ version }}/srobo-robot-{{ version }}.img.xz">
+        <a class="kit-download-link" data-version="{{ version }}" href="https://github.com/srobo/robot-image/releases/download/v{{ version }}/srobo-robot-{{ version }}.img.xz">
           Download {{ version }}
         </a>
       </td>

--- a/_includes/updates-table.html
+++ b/_includes/updates-table.html
@@ -3,7 +3,6 @@
     <th></th>
     <th>Release Date</th>
     <th>Download</th>
-    <th>Licences</th>
   </tr>
   {% for kit_version in site.data.kit_versions %}
     {% assign version = kit_version.version %}
@@ -21,7 +20,6 @@
           Download {{ version }}
         </a>
       </td>
-      <td><a href="https://kit-downloads.studentrobotics.org/kit-software/{{ version }}/srobo-robot-{{ version }}-licences">Licences</a></td>
     </tr>
   {% endfor %}
 </table>

--- a/kit/brain_board/updates.md
+++ b/kit/brain_board/updates.md
@@ -12,6 +12,10 @@ Once you have downloaded the file you need, refer to the documentation on [updat
 
 Each update file is a complete upgrade. Each file contains the changes of those before it. If you need to jump up multiple versions, you can do so by using the latest file.
 
+{% if site.data.kit_versions.size > 0 %}
 The following table outlines the updates which have been published.
 
 {% include updates-table.html %}
+{% else %}
+There are currently no updates available.
+{% endif %}


### PR DESCRIPTION
- Add check for 0 updates being available.
- Download images from GitHub Releases
- Remove licence information. We are going to stop publishing it as the robot-image repo has the information.