### PR TITLE
Standardise around 5 tilde characters (~)

### DIFF
--- a/programming/sr/compass/index.md
+++ b/programming/sr/compass/index.md
@@ -11,10 +11,10 @@ This documentation refers to a feature which is only available within the simula
 
 The `sr.robot` library contains support for using a simulated compass unit on the robot. This allows robots to determine the direction it's facing in the arena.
 
-```python
+~~~~~ python
 from sr.robot import *
 R = Robot()
 heading = R.compass.get_heading()
-```
+~~~~~
 
 When called, the `get_heading` method will return the heading of the robot in radians as a float. The heading is in the range 0 to tau (2π), where 0 is the robot facing directly North, and values increasing clockwise.

--- a/programming/sr/radio/index.md
+++ b/programming/sr/radio/index.md
@@ -68,9 +68,9 @@ The simplest approach is to use the `claim_territory` method, which will take
 care of sending the signals as well as ensuring that the proper amount of time
 passes between them:
 
-~~~~ python
+~~~~~ python
 R.radio.claim_territory()
-~~~~
+~~~~~
 
 This function takes a couple of seconds to complete and you must stay within
 range of the territory for the whole duration it is running for your claim to
@@ -81,13 +81,13 @@ No information is returned from `claim_territory`.
 Alternatively if you would like to be able to control your robot while also
 making a territory claim, you can instead manage the claim signals directly:
 
-~~~~ python
+~~~~~ python
 R.radio.begin_territory_claim()
 
 # Do stuff here
 
 R.radio.complete_territory_claim()
-~~~~
+~~~~~
 
 Note that when using `begin_territory_claim` and `complete_territory_claim` you
 are also responsible for ensuring that the proper amount of time (two seconds)


### PR DESCRIPTION
While this is a little unusual for markdown these days, having a consistent style is better than a mixture as it enables easier searching for code blocks.