### PR TITLE
Ingore node_modules when building the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ exclude:
   - gems/
   - Dockerfile
   - docker-compose.yml
+  - node_modules/
   - _env/
   - _docs/
   - vendor/


### PR DESCRIPTION
This won't be present when GitHub Pages builds the site, so having it present is merely likely to create confusion (as well as slow down the build locally/in CI).