### PR TITLE
Document the noise we add to the simulator

### DIFF
--- a/simulator/programming/index.md
+++ b/simulator/programming/index.md
@@ -36,8 +36,8 @@ The simulator’s API is very similar to the real SR API described in the [progr
 
 <div class="info">
   To more closely reflect reality, artificial noise has been added to simulated
-  values such that sensors and actuators are not perfectly are not perfectly
-  accurate, and may fluctuate slightly between measurements or operations.
+  values such that sensors and actuators are not perfectly accurate, and may
+  fluctuate slightly between measurements or operations.
 </div>
 
 ### Motors

--- a/simulator/programming/index.md
+++ b/simulator/programming/index.md
@@ -34,6 +34,12 @@ To allow this simulated robot to move around and sense its environment a set of 
 
 The simulator’s API is very similar to the real SR API described in the [programming docs]({{ site.baseurl }}/programming/), with the exception of `R.time` and `R.sleep`.
 
+<div class="info">
+  To more closely reflect reality, artificial noise has been added to simulated
+  values such that sensors and actuators are not perfectly are not perfectly
+  accurate, and may fluctuate slightly between measurements or operations.
+</div>
+
 ### Motors
 
 Your robot has one motor board attached, the left wheel is connected to the first port, and the right wheel to the second.


### PR DESCRIPTION
This is largely stolen from https://github.com/srobo/docs/pull/191, though placed in a location that more clearly applies to the whole simulator rather than just the radio.

Fixes https://github.com/srobo/docs/issues/190
Replaces https://github.com/srobo/docs/pull/191