### PR TITLE
Document how to use the LEDs on the KCH HAT

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -47,6 +47,8 @@ tree:
       tree:
       - url: /programming/sr/cheat_sheet
         title: API Quick Reference
+      - url: /programming/sr/leds/
+        title: LEDs
       - url: /programming/sr/motors/
         title: Motors
       - url: /programming/sr/power/

--- a/programming/sr/leds/index.md
+++ b/programming/sr/leds/index.md
@@ -9,7 +9,7 @@ LEDs
 The KCH HAT provides diagnostic information about the state of your robot
 through a collection of preconfigured and user-controllable LEDs. It is part of
 the [Brain Board](/docs/kit/brain_board) assembly, however control of its LEDs
-is provide through a distinct API.
+is provided through a distinct API.
 
 The LEDs on the KCH can be accessed via the `kch` object:
 

--- a/programming/sr/leds/index.md
+++ b/programming/sr/leds/index.md
@@ -47,3 +47,15 @@ R.kch.c.rgb = (1, 1, 0)
 # Set LED B to a light blue colour
 R.kch.b.rgb = (0, 1, 1)
 ~~~~~
+
+You can also access all the LEDs together:
+
+~~~~~ python
+# Turn on the blue channel of all the LEDs
+for led in R.kch.leds.values():
+    led.blue = 1
+
+# Set all LEDs to a purple colour
+for led in R.kch.leds.values():
+    led.rgb = (1, 0, 1)
+~~~~~

--- a/programming/sr/leds/index.md
+++ b/programming/sr/leds/index.md
@@ -45,5 +45,5 @@ Alternatively you can set the red, green and blue channels for a given LED all t
 R.kch.c.rgb = (1, 1, 0)
 
 # Set LED B to a light blue colour
-R.kch.b.green = (0, 1, 1)
+R.kch.b.rgb = (0, 1, 1)
 ~~~~~

--- a/programming/sr/leds/index.md
+++ b/programming/sr/leds/index.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: LEDs
+---
+
+LEDs
+====
+
+The KCH HAT provides diagnostic information about the state of your robot
+through a collection of preconfigured and user-controllable LEDs. It is part of
+the [Brain Board](/docs/kit/brain_board) assembly, however control of its LEDs
+is provide through a distinct API.
+
+The LEDs on the KCH can be accessed via the `kch` object:
+
+~~~~~ python
+R.kch.something...
+~~~~~
+
+[LEDs](#leds) {#leds}
+---------------------
+
+The KCH HAT has three RGB LEDs: A, B and C. The LEDs default to off, however
+once set they will hold their value even if your code exits. This is potentially
+useful to understand the current state of your code as it runs or the final
+state of the code afterwards.
+
+Each channel of each LED acts independently, so you can either set them separately:
+
+~~~~~ python
+# Turn on the red channel of LED A
+R.kch.a.red = 1
+
+# Turn on the green channel of LED B
+R.kch.b.green = 1
+
+# Turn off the red channel of LED A
+R.kch.a.red = 0
+~~~~~
+
+Alternatively you can set the red, green and blue channels for a given LED all together:
+
+~~~~~ python
+# Set LED C to a yellow colour
+R.kch.c.rgb = (1, 1, 0)
+
+# Set LED B to a light blue colour
+R.kch.b.green = (0, 1, 1)
+~~~~~


### PR DESCRIPTION
I've opted to name this document after the LEDs it controls, rather than the board where those LEDs are hosted, to follow the naming pattern of the "motors", "servos" (etc.) docs which do the same for the other boards. This should be easy to change if naming this after the host board would be preferred.

This is based on the current state of the API integration in https://github.com/srobo/sr-robot3/pull/60 and with reference to [`kch.py` in J5](https://github.com/j5api/j5/blob/main/j5/boards/sr/kch.py), so may not be quite how this is intended to function. Hopefully there's a useful starting point here though.

Fixes https://github.com/srobo/docs/issues/358