### PR TITLE
Make Kit Assembly video less square

### DIFF
--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -106,9 +106,15 @@
     background: white;
     border: 1px solid silver;
     padding: 3px;
+    max-height: 25vh;
+
+    @media (orientation: landscape) {
+      max-height: 90vh;
+    }
 
     @include media-query('medium') {
       min-height: 480px;
+      max-height: initial;
     }
   }
 

--- a/kit/assembly.md
+++ b/kit/assembly.md
@@ -64,8 +64,8 @@ The following video contains an overview which covers the [brain board](/docs/ki
 
 <div class="centered-content">
   <iframe class="video center"
-          height="315"
-          width="560"
+          height="480"
+          width="640"
           src="https://www.youtube-nocookie.com/embed/HQmL_3giLvc?rel=0"
           frameborder="0"
           allowfullscreen>


### PR DESCRIPTION
Think we could still make this better but think there are more important things to spend time on right now :)

<details>
<summary>Desktop</summary>

![image](https://user-images.githubusercontent.com/1496834/197260879-2b495e11-f8f0-4efc-8a09-76a7d0cb60ee.png)
</details>

<details>
<summary>Mobile (Portatit)</summary>

![image](https://user-images.githubusercontent.com/1496834/197261050-ac98f067-1757-4234-9022-74fba1bc9f31.png)

</details>

<details>
<summary>Mobile (Landscape)</summary>

![image](https://user-images.githubusercontent.com/1496834/197262705-e526c1b1-3703-43c2-b397-34fdab989423.png)

</details>