### PR TITLE
Add docs on the robot-settings.toml file

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -20,6 +20,7 @@ srobo
 ST7202USBGB
 studentrobotics
 usbkey
+usercode
 Webots
 Zoloto
 

--- a/kit/brain_board/index.md
+++ b/kit/brain_board/index.md
@@ -78,3 +78,19 @@ If you choose to use a tool other than Etcher, you may need to extract the `srob
    Your computer may complain that the SD card is no longer readable, however
    this is expected as the data being written to the SD card is not in a format
    that either Windows or macOS can natively understand.
+
+## Robot Settings
+
+Some of the features on your robot are configured using a settings file, called `robot-settings.toml`. This file is automatically created on your USB drive the first time that you run any code on your robot.
+
+You can edit the settings file using your IDE or any text editor.
+
+The robot settings file contains the following settings:
+
+| Setting Name          | Description                                | Default Value      |
+|-----------------------|--------------------------------------------|--------------------|
+| `team_tla`            | Three Letter Acryonym (TLA) for your team. | Randomly generated |
+| `wifi_psk`            | Password for the Robot WiFi                | Randomly generated |
+| `wifi_region`         | Region Identifier for the WiFi             | `GB`               |
+| `wifi_enabled`        | Enables the WiFi                           | `true`             |
+| `usercode_entrypoint` | The entry point to your Python code        | `robot.py`         |

--- a/kit/brain_board/index.md
+++ b/kit/brain_board/index.md
@@ -89,7 +89,7 @@ The robot settings file contains the following settings:
 
 | Setting Name          | Description                                | Default Value      |
 |-----------------------|--------------------------------------------|--------------------|
-| `team_tla`            | Three Letter Acryonym (TLA) for your team. | Randomly generated |
+| `team_tla`            | Three Letter Acronym (TLA) for your team.  | Randomly generated |
 | `wifi_psk`            | Password for the Robot WiFi                | Randomly generated |
 | `wifi_region`         | Region Identifier for the WiFi             | `GB`               |
 | `wifi_enabled`        | Enables the WiFi                           | `true`             |

--- a/kit/wifi.md
+++ b/kit/wifi.md
@@ -18,6 +18,10 @@ Your robot has now set up its very own WiFi network! It will initially have a na
 You can now connect to your robot in the same way you normally connect to a WiFi network.
 You will need a WiFi key to be able to connect and you can find this inside `robot-settings.toml` on the USB drive containing your code.
 
+<div class="info">
+    If there is no <code>robot-settings.toml</code> on your USB drive, you can generate one by first running any code on your robot. For more information see our docs on <a href="{{ site.baseurl }}/kit/brain_board#robot-settings">Robot Settings</a>.
+</div>
+
 These details can also be printed using:
 ~~~~ python
 R.print_wifi_details()


### PR DESCRIPTION
We need to document how the `robot-settings.toml` file is created and what the settings in it mean.

This is the file that students need to edit to customise their WiFi password. It is automatically generated if a USB drive is inserted containing a `robot.py`