### PR TITLE
Update "Getting Code on the Robot" to include icon reference for Windows 11 context menu

### DIFF
--- a/programming/getting_code_on_the_robot.md
+++ b/programming/getting_code_on_the_robot.md
@@ -22,7 +22,7 @@ back in again and it will restart automatically.
 
 1. Open your code in File Explorer
 2. Select all of your code files (<kbd>Ctrl</kbd><kbd>A</kbd> to select all files)
-3. Right-click the files and click "Copy"
+3. Right-click the files and click "Copy" (<i class="fa-regular fa-copy"></i> on Windows 11)
 4. Open your USB drive in File Explorer
 5. Right-click in the directory and click "Paste"
 

--- a/programming/getting_code_on_the_robot.md
+++ b/programming/getting_code_on_the_robot.md
@@ -22,7 +22,7 @@ back in again and it will restart automatically.
 
 1. Open your code in File Explorer
 2. Select all of your code files (<kbd>Ctrl</kbd><kbd>A</kbd> to select all files)
-3. Right-click the files and click "Copy" (<i class="fa-regular fa-copy"></i> on Windows 11)
+3. Right-click the files and click "Copy" <span aria-hidden="true">(<i class="fa-regular fa-copy"></i> on Windows 11)</span>
 4. Open your USB drive in File Explorer
 5. Right-click in the directory and click "Paste"
 


### PR DESCRIPTION
Reference of said context menu:
![image](https://user-images.githubusercontent.com/6197148/205177280-72a4943b-2c9d-4b1c-8180-a6533243139e.png)
