### PR TITLE
Support Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,6 @@ gem 'html-proofer'
 
 # Avoid polling on windows
 gem 'wdm', '>= 0.1.0'
+
+# For local Ruby 3 support; works around https://github.com/github/pages-gem/issues/752
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     wdm (0.1.1)
+    webrick (1.7.0)
     yell (2.2.2)
     zeitwerk (2.6.1)
 
@@ -102,6 +103,7 @@ DEPENDENCIES
   neat
   rake
   wdm (>= 0.1.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'set'
 require 'yaml'
 
@@ -15,6 +16,12 @@ task :dependencies do
   else
     sh('bundle install --path gems')
   end
+
+  # Fix pathutil on Ruby 3; works around https://github.com/envygeeks/pathutil/pull/5
+  # as suggested by https://stackoverflow.com/a/73909894/67873
+  pathutil_path = `bundle exec gem which pathutil`.strip()
+  content = File.read(pathutil_path).gsub(', kwd', ', **kwd')
+  File.write(pathutil_path, content)
 end
 
 task :spelling_dependencies do


### PR DESCRIPTION
This ports the changes from https://github.com/srobo/website/pull/473.

This isn't officially supported by Jekyll and is a bit hacky, so I'm deliberately not documenting the support, however as recent Ubuntu versions now ship with Ruby 3 (not 2.7) and Jekyll isn't showing any signs of moving towards supporting Ruby 3 we're not left with many alternatives.