### PR TITLE
Teach git in the docker container to trust our git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ENV GLOBAL_GEMS=true
 
 WORKDIR /usr/src/docs
 
+RUN git config --global --add safe.directory /usr/src/docs && git config --global --add safe.directory /usr/src/docs/_sass/brand
+
 RUN gem install 'bundler:~>1' rake
 
 COPY . ./


### PR DESCRIPTION
Without this it sees the git repo as being owned by the external user, which is different to the root user that is running in the container. This seems to mostly impact CI, where the submodules aren't cloned by default.