### PR TITLE
Add version and release date to simulator link

### DIFF
--- a/simulator/index.md
+++ b/simulator/index.md
@@ -32,11 +32,18 @@ There are a small number of [external libraries]({{ site.baseurl }}/programming/
 which will be available to your robot code during the competition. Note that for
 local development you will need to install these yourself.
 
+### Downloading the simulation
+
+The latest version of the simulator you can download it here:
+
+[Download the simulation](https://github.com/srobo/competition-simulator/releases/download/sr2023.4/competition-simulator-sr2023.4.zip) (sr2023.4, released: 2023-02-15)
+
+Please ensure you also have webots installed to run the simulation (see 'Prerequisites' above).
+
 ### Installing the simulation
 
 1. Create a directory, perhaps called `simulation` where you will store your robot code.
-2. [Download the simulation](https://github.com/srobo/competition-simulator/releases/download/sr2023.4/competition-simulator-sr2023.4.zip)
-  and unzip it as a subdirectory of that directory:
+2. Download the simulation (see above) and unzip it as a subdirectory of that directory:
   ```
   simulation
   ├── competition-simulator-<version>


### PR DESCRIPTION
Add the version and release date to the simulator link, also move it into its own section to make it a bit easier to find.

Also add a reminder to download webots, in the likely case the user isn't reading all the docs