### PR TITLE
Update page on python libraries

### DIFF
--- a/kit/brain_board/python_libraries.md
+++ b/kit/brain_board/python_libraries.md
@@ -44,5 +44,6 @@ The list below outlines the differences.
 
 <!-- cspell:disable -->
 * `flask` is not available in the simulator
+* `opencv` is not available in the simulator
 <!-- cspell:enable -->
 

--- a/kit/brain_board/python_libraries.md
+++ b/kit/brain_board/python_libraries.md
@@ -4,8 +4,8 @@ title: Available Python Libraries
 ---
 
 <!-- Simulator libraries https://github.com/srobo/competition-simulator/blob/main/libraries.txt -->
-<!-- Robot image libraries https://github.com/srobo/robot-image/blob/main/libraries.txt -->
-<!-- Robot image requirements https://github.com/srobo/robot-image/blob/main/requirements.txt -->
+<!-- Robot image libraries https://github.com/srobo/robot-image/blob/main/files/python/libraries.txt -->
+<!-- Robot image requirements https://github.com/srobo/robot-image/blob/main/files/python/requirements.txt -->
 
 # Available Python Libraries
 
@@ -43,7 +43,9 @@ Generally we will try to keep the libraries available in the simulator the same 
 The list below outlines the differences.
 
 <!-- cspell:disable -->
+* `debugpy` is not available in the simulator
 * `flask` is not available in the simulator
 * `opencv` is not available in the simulator
+* `sr-robot3` that comes with the simulator has the same API but is different to the one available on pypi
 <!-- cspell:enable -->
 

--- a/kit/brain_board/python_libraries.md
+++ b/kit/brain_board/python_libraries.md
@@ -3,8 +3,18 @@ layout: page
 title: Available Python Libraries
 ---
 
+<!-- Simulator libraries https://github.com/srobo/competition-simulator/blob/main/libraries.txt -->
+<!-- Robot image libraries https://github.com/srobo/robot-image/blob/main/libraries.txt -->
+<!-- Robot image requirements https://github.com/srobo/robot-image/blob/main/requirements.txt -->
 
 # Available Python Libraries
+
+If you wish to use a library that isn't in the list, get in contact with us on Discord and have a chat with us about it.
+
+<div class="info" markdown="1">
+Note that for local development in the simulator you will need to install the libraries yourself.
+Look at the guide on [setting up the simulator]({{ site.baseurl }}/tutorials/setting_up_simulator) to find out how to do this.
+</div>
 
 
 ## Robot Kit
@@ -12,65 +22,27 @@ title: Available Python Libraries
 The following python libraries are installed and available for use in your robot's software:
 
 <!-- cspell:disable -->
-* [april-vision 1.0.2](https://pypi.org/project/april-vision)
-* [astoria 0.11.1](https://pypi.org/project/astoria)
-* [cached-property 1.5.2](https://pypi.org/project/cached-property)
-* [click 8.1.2](https://pypi.org/project/click)
-* [cycler 0.11.0](https://pypi.org/project/cycler)
-* [dateutil 2.8.2](https://pypi.org/project/python-dateutil)
-* [debugpy 1.6.3](https://pypi.org/project/debugpy)
-* [dbus-next 0.2.3](https://pypi.org/project/dbus-next)
-* [docopt 0.6.2](https://pypi.org/project/docopt)
-* [gmqtt 0.6.11](https://pypi.org/project/gmqtt)
-* [gpg 1.17.1](https://pypi.org/project/gpg)
-* [iniparse 0.5](https://pypi.org/project/iniparse)
-* [j5 1.1.2](https://pypi.org/project/j5)
-* [kchd 0.4.1](https://pypi.org/project/kchd)
-* [matplotlib 3.5.1](https://pypi.org/project/matplotlib)
-* [numpy 1.22.3](https://pypi.org/project/numpy)
-* opencv 4.5.5
-* [paho-mqtt 1.6.1](https://pypi.org/project/paho-mqtt)
-* [pandas 1.4.2](https://pypi.org/project/pandas)
-* [Pillow 9.0.1](https://pypi.org/project/Pillow)
-* [prompt-toolkit 3.0.24](https://pypi.org/project/prompt-toolkit)
-* [pyapriltags 3.3.0.post2](https://pypi.org/project/pyapriltags)
-* [pydantic 1.9.1](https://pypi.org/project/pydantic)
-* [PyGObject 3.42.0](https://pypi.org/project/PyGObject)
-* [pyparsing 3.0.7](https://pypi.org/project/pyparsing)
-* [pyquaternion 0.9.9](https://pypi.org/project/pyquaternion)
-* [pyserial 3.5](https://pypi.org/project/pyserial)
-* [pytz 2022.1](https://pypi.org/project/pytz)
-* [pyudev 0.23.2](https://pypi.org/project/pyudev)
-* [pyusb 1.2.1](https://pypi.org/project/pyusb)
-* [pyyaml 6.0](https://pypi.org/project/PyYAML)
-* [RPi.GPIO 0.7.0](https://pypi.org/project/rpi.gpio)
-* [rtui 0.1.1](https://pypi.org/project/rtui)
-* [setuptools 59.5.0](https://pypi.org/project/setuptools)
-* [six 1.16.0](https://pypi.org/project/six)
-* [sr.robot3 2023.2.0](https://pypi.org/project/sr.robot3)
-* [tomli 2.0.1](https://pypi.org/project/tomli)
-* [tomli-w 1.0.0](https://pypi.org/project/tomli-w)
-* [typing-extensions 3.10.0.0](https://pypi.org/project/typing-extensions)
-* [udiskie 2.3.3](https://pypi.org/project/udiskie)
+* [debugpy 1.7.0](https://pypi.org/project/debugpy)
+* [flask 2.3.3](https://pypi.org/project/flask)
+* [matplotlib 3.7.2](https://pypi.org/project/matplotlib)
+* [networkx 3.1](https://pypi.org/project/networkx)
+* [numpy 1.24.4](https://pypi.org/project/numpy)
+* [opencv-python-headless 4.8.0.76](https://pypi.org/project/opencv-python-headless)
+* [pandas 2.0.3](https://pypi.org/project/pandas)
+* [pillow 10.0.0](https://pypi.org/project/pillow)
+* [scikit-learn 1.3.0](https://pypi.org/project/scikit-learn)
+* [scipy 1.10.1](https://pypi.org/project/scipy)
+* [shapely 2.0.1](https://pypi.org/project/shapely)
+* [sr-robot3 2024.0.0](https://pypi.org/project/sr-robot3)
 <!-- cspell:enable -->
 
-If you wish to use a library that isn't listed above, get in contact with us on Discord and have a chat with us about it.
 
+## Simulator differences
 
-## Simulator
+Generally we will try to keep the libraries available in the simulator the same as what is available on the physical robot.
+The list below outlines the differences.
 
-The following libraries will be available to your robot code during the
-competition. Note that for local development you will need to install these
-yourself.
-
-<!-- updating this list? Also update https://github.com/srobo/competition-simulator/blob/master/libraries.txt -->
 <!-- cspell:disable -->
-
-* [matplotlib 3.5.1](https://pypi.org/project/matplotlib/3.5.1/)
-* [numpy 1.22.3](https://pypi.org/project/numpy/1.22.3/)
-* [pandas 1.4.2](https://pypi.org/project/pandas/1.4.2/)
-* [typing-extensions 3.10.0.0](https://pypi.org/project/typing-extensions/3.10.0.0/)
+* `flask` is not available in the simulator
 <!-- cspell:enable -->
 
-If there are other libraries you would like included, please get in contact with
-us on Discord and have a chat with us about it.

--- a/tutorials/setting_up_simulator.md
+++ b/tutorials/setting_up_simulator.md
@@ -24,9 +24,8 @@ You will also need Python installed.
 | macOS    | 3.8-3.10                 |
 | Linux    | 3.8-3.10                 |
 
-There are a small number of [external libraries]({{ site.baseurl }}/kit/brain_board/python_libraries#simulator)
-which will be available to your robot code during the competition. Note that for
-local development you will need to install these yourself.
+There are a small number of [external libraries]({{ site.baseurl }}/kit/brain_board/python_libraries) which will be available to your robot code during the competition.
+Note that for local development you will need to install these yourself.
 
 ### Installing the simulation
 


### PR DESCRIPTION
Libraries synced between the image and simulator, python libs page updated to reflect this

Simulator libraries https://github.com/srobo/competition-simulator/blob/main/libraries.txt
Robot image libraries https://github.com/srobo/robot-image/blob/main/libraries.txt
Robot image requirements https://github.com/srobo/robot-image/blob/main/requirements.txt