### PR TITLE
Update img release for this years initial image release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ task :validate_kit_versions do
   data = YAML.load_file('_data/kit_versions.yml')
   data.each do |entry|
     actual = entry.keys.to_set
-    expected = ['version', 'released', 'changelog'].to_set
+    expected = ['version', 'released', 'link', 'changelog'].to_set
     optional = ['yanked'].to_set
     missing = expected - actual - optional
     extra = actual - expected - optional

--- a/_data/kit_versions.yml
+++ b/_data/kit_versions.yml
@@ -2,7 +2,12 @@
 # The format of this file should be like such:
 # - version: 20xx.y.z
 #   released: 2038-01-19
+#   link: https://link-to-download.img
 #   changelog:
 #     - Changed something
 #     - Changed another thing too
-[]
+- version: 2024.1.0
+  released: 2023-09-14
+  link: https://github.com/srobo/robot-image/releases/download/2024.1.0/Student.Robotics.OS-image-2024.1.0.img.xz
+  changelog:
+    - Initial release for SR2024.

--- a/_includes/updates-list.html
+++ b/_includes/updates-list.html
@@ -8,7 +8,7 @@
   {% if kit_version.yanked %}
   <p>This version is no longer available.</p>
   {% else %}
-  <a class="kit-download-link" data-version="{{ version }}" href="https://github.com/srobo/robot-image/releases/download/v{{ version }}/srobo-image-robot-{{ version }}.img.xz">
+  <a class="kit-download-link" data-version="{{ version }}" href="{{ kit_version.link }}">
       Download {{ version }}
   </a>
   {% endif %}

--- a/kit/brain_board/python_libraries.md
+++ b/kit/brain_board/python_libraries.md
@@ -33,7 +33,7 @@ The following python libraries are installed and available for use in your robot
 * [scikit-learn 1.3.0](https://pypi.org/project/scikit-learn)
 * [scipy 1.10.1](https://pypi.org/project/scipy)
 * [shapely 2.0.1](https://pypi.org/project/shapely)
-* [sr-robot3 2024.0.0](https://pypi.org/project/sr-robot3)
+* [sr-robot3 2024.0.1](https://pypi.org/project/sr-robot3)
 <!-- cspell:enable -->
 
 


### PR DESCRIPTION
Also change yaml to define link. This allows for flexibility if something about the link changes (we had this issue last year). It also pulls all the hardcoded data into the single yaml file instead of being spead between the two files.