### PR TITLE
Bump GitHub Actions Checkout

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
       # See https://github.com/ruby/setup-ruby/issues/291
       GLOBAL_GEMS: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -31,7 +31,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Build container
       run: docker-compose build


### PR DESCRIPTION
This avoids deprecation of Node 16 which is likely to come soon given that it is now beyond end of life.