### PR TITLE
Canonicalise around Robot instances being 'robot'

### DIFF
--- a/programming/power.md
+++ b/programming/power.md
@@ -109,13 +109,13 @@ The frequency on the buzzer is limited from 8Hz to 10,000Hz
 
 ~~~~~ python
 # Beep for 0.5s in D.
-R.power_board.piezo.buzz(Note.D6, 0.5)
+robot.power_board.piezo.buzz(Note.D6, 0.5)
 
 # Beep for 2s at 400Hz
-R.power_board.piezo.buzz(400, 2)
+robot.power_board.piezo.buzz(400, 2)
 
 # Beep for 3s at 250Hz and wait for it to finish
-R.power_board.piezo.buzz(250, 3, blocking=True)
+robot.power_board.piezo.buzz(250, 3, blocking=True)
 ~~~~~
 
 


### PR DESCRIPTION
This makes type checking the docs much easier.

Fixes https://github.com/srobo/docs/issues/531