### PR TITLE
Remove a redundant kit software version warning

### DIFF
--- a/tutorials/editors/vscode.md
+++ b/tutorials/editors/vscode.md
@@ -40,10 +40,6 @@ you'll need to make the library available within the Python environment that you
 
 ## Remote Debugging
 
-<div class="info">
-This documentation refers to a feature which is only available from software version <code>2023.1.0</code> and later.
-</div>
-
 When connected to the [robot's WiFi hotspot]({{ site.baseurl }}/kit/brain_board/web_interface), it is possible to attach VS Code's
 debugger to the robot by performing the following steps:
 


### PR DESCRIPTION
I'm assuming that all the SR2024 kit versions now support this.