### PR TITLE
Add links to a version-zero release of the SR2024 simulator

### DIFF
--- a/simulator/setting_up_simulator.md
+++ b/simulator/setting_up_simulator.md
@@ -28,12 +28,8 @@ Note that for local development you will need to install these yourself.
 
 ### Installing the simulation
 
-The simulation for the SR2024 competition will be released at Kickstart.
-
-<!--
-
 1. Create a directory, perhaps called `simulation` where you will store your robot code.
-2. [Download the simulation](https://github.com/srobo/competition-simulator/releases/download/TODO/competition-simulator-TODO.zip), the latest version is TODO, released on TODO.
+2. [Download the simulation](https://github.com/srobo/competition-simulator/releases/download/sr2024.0/competition-simulator-sr2024.0.zip), the latest version is `sr2024.0`, released on 2023-10-17, which is a preview to aid in setting up the simulator. The simulation for the SR2024 competition will be released at Kickstart.
 3. Unzip the simulation as a subdirectory of the directory you created in the first step:
     ```
     simulation
@@ -48,8 +44,6 @@ The simulation for the SR2024 competition will be released at Kickstart.
 4. Using the Webots IDE, open the `worlds/Arena.wbt` file.
 
 You may receive a warning about your computer's GPU not being good enough, which can be ignored.
-
--->
 
 <div class="info">
   On recent versions of macOS you may need to give Webots permission to access the directory where you have extracted the simulation files.


### PR DESCRIPTION
Useful if we do want to do this to help teams get set up ahead of time.

Note: at the time of writing the link included here doesn't exist.

Depends on us shipping https://github.com/srobo/competition-simulator/pull/435 as `sr2024.0`.