### PR TITLE
Hide the links to download the simulation files

### DIFF
--- a/simulator/setting_up_simulator.md
+++ b/simulator/setting_up_simulator.md
@@ -28,6 +28,10 @@ Note that for local development you will need to install these yourself.
 
 ### Installing the simulation
 
+The simulation for the SR2024 competition will be released at Kickstart.
+
+<!--
+
 1. Create a directory, perhaps called `simulation` where you will store your robot code.
 2. [Download the simulation](https://github.com/srobo/competition-simulator/releases/download/TODO/competition-simulator-TODO.zip), the latest version is TODO, released on TODO.
 3. Unzip the simulation as a subdirectory of the directory you created in the first step:
@@ -44,6 +48,8 @@ Note that for local development you will need to install these yourself.
 4. Using the Webots IDE, open the `worlds/Arena.wbt` file.
 
 You may receive a warning about your computer's GPU not being good enough, which can be ignored.
+
+-->
 
 <div class="info">
   On recent versions of macOS you may need to give Webots permission to access the directory where you have extracted the simulation files.


### PR DESCRIPTION
We've not released these yet and may not do so before Kickstart.

This is needed to unblock https://github.com/srobo/team-emails/pull/159