### PR TITLE
Make it clearer that code runs on the robot

### DIFF
--- a/programming/index.md
+++ b/programming/index.md
@@ -7,12 +7,11 @@ title: Programming
 
 # Programming Your Robot
 
-Robots built using the SR kit are programmed with [Python 3.11](https://www.python.org) which is made possible with a custom-built Python library, `sr.robot3`.
+Robots built using the SR kit are programmed with [Python 3.11](https://www.python.org) which is made possible with a custom-built Python library, `sr.robot3`, which is pre-installed on your robot.
 This library deals with talking to the boards and doing all the complicated bits so you can focus on the fun bits.
 
 The [Robot API]({{ site.baseurl }}/programming/robot_api/) page has the details about this library.
 The other pages in this section contain all of the information you need to know to successfully code for your robot.
-
 
 ## Learning python
 
@@ -35,6 +34,9 @@ There are a number of tutorials out there which might help you to learn to progr
 
 ## Writing code
 
-In order to develop the code for your robot, we recommend that you use a code editor.
+In order to develop the code for your robot, you will write it on your computer and then [transfer it to your robot]({{ site.baseurl }}/tutorials/getting_code_on_the_robot). Unlike other code you may be used to writing, you won't be able to run your robot code from your computer &mdash; it needs to be run on your robot.
+
 A good code editor can provide you with features such as auto completion and syntax highlighting which will help you more easily write code.
 For suggestions of suitable editors, and how to set them up see the [Code Editors]({{ site.baseurl }}/tutorials/editors/) section.
+
+Other than an editor to write the code, you don't need anything else to get started.

--- a/tutorials/getting_code_on_the_robot.md
+++ b/tutorials/getting_code_on_the_robot.md
@@ -7,6 +7,9 @@ title: Getting Code on the Robot
 
 # Getting Code on the Robot
 
+For your robot to function, it needs some code to tell it what to do.
+This code will be written on your computer, but then needs to be transferred to your robot to execute it.
+
 Getting your code on to the robot is quite simple.
 You will need to put your code on a USB drive which will need to be formatted with either FAT32, exFAT or ext2/3/4.
 Upon plugging in the drive or starting up, the robot will run the `robot.py` file found in the root of the drive.


### PR DESCRIPTION
Following a conversation in Discord, I realised we don't make it especially clear that the code shouldn't (ie couldn't) be run from your computer, and instead should be edited there but run on the robot.

This PR tries to clear that up, mostly by littering references to it throughout the relevant parts of the docs.