### PR TITLE
Link from the hardware docs to the software docs

### DIFF
--- a/kit/arduino.md
+++ b/kit/arduino.md
@@ -17,6 +17,9 @@ This makes for easier connection of wires to the Arduino.
 
 The Arduino only needs to be connected to the kit over USB as it uses this for both power and communication.
 
+The Arduino in your kit has been preloaded with [firmware]({{ site.baseurl }}/programming/arduino/sr_firmware) allowing its inputs and outputs to be used from your Python code.
+You can also load your own firmware onto the Arduino to extend its capabilities -- see [Arduino API]({{ site.baseurl }}/programming/arduino) for details.
+
 ## Board Diagram
 
 ![Ruggeduino diagram]({{ site.baseurl }}/images/content/kit/ruggeduino_diagram.png "The Ruggeduino")

--- a/kit/brain_board/index.md
+++ b/kit/brain_board/index.md
@@ -19,8 +19,7 @@ The Brain Board provided with your kit is what runs the code you write and contr
 It consists of a [Raspberry Pi 4B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) and a Student Robotics KCH.
 
 The KCH is the board installed on top of the Pi, it powers the brain and has LEDs to show the current status of the robot.
-There are also 3 RGB (Red, Green, and Blue) LEDs that you can control from your code.
-
+There are also 3 RGB (Red, Green, and Blue) LEDs that you can control from your code -- see the [Brain Board LED API]({{ site.baseurl }}/programming/leds) for details.
 
 ## Board Diagram
 

--- a/kit/motor_board.md
+++ b/kit/motor_board.md
@@ -14,6 +14,8 @@ The speed and direction of the two outputs are controlled independently through 
 The motor board uses [pulse-width modulation][wiki-pwm] (PWM) to control the
 amount of power that is sent to the motors.
 
+You can control the motors using the [Motor Board API]({{ site.baseurl }}/programming/motors).
+
 [wiki-pwm]: https://en.wikipedia.org/wiki/Pulse-width_modulation
 
 Board Diagram

--- a/kit/power_board.md
+++ b/kit/power_board.md
@@ -11,6 +11,7 @@ Power Board
 </a>
 The Power Board distributes power to the SR kit from the battery.
 It provides eight general-purpose power outputs, with port L2 reserved for powering the Brain Board.
+You can control the state of these outputs from the [Power Board API]({{ site.baseurl }}/programming/power).
 
 It also holds the internal On|Off switch for the whole robot as well as
 the Start button which is used to start your robot code running.

--- a/kit/servo_board.md
+++ b/kit/servo_board.md
@@ -12,6 +12,8 @@ Servo Board
 The Servo Board can be used to control up to 12 RC servos.
 Many devices are available that can be controlled as servos, such as RC motor speed controllers, so these can also be used with this board.
 
+You can control the state of each servo output from the [Servo Board API]({{ site.baseurl }}/programming/servos).
+
 Board Diagram
 -------------
 <img src="{{ site.baseurl }}/images/content/kit/servo_board_v4_diagram.png" alt="A diagram of a servo board" />


### PR DESCRIPTION
We've had links the other way for a long time, but not this way around. Adding these makes the docs more easily navigable.