### PR TITLE
Various README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Once setup, the site will be accessible on http://localhost:4000/docs/
     $ rake dev
     ```
 
+4. View the website at <http://localhost:4000/docs/>
+
 ## Making changes
 
 When you've made a change, either push it to a forked repository, or to a

--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ The Student Robotics public documentation.
 
 ## Getting Started
 
-For ease of setup, a Docker container is provided. Simply install Docker and `docker-compose`, and run `docker-compose up`.
-
-Once setup, the site will be accessible on http://localhost:4000/docs/
-
-### Manual
-
 0. [Clone this repo][clone-repo]
 
 1. [Install Ruby][install-ruby]
@@ -27,6 +21,14 @@ Once setup, the site will be accessible on http://localhost:4000/docs/
     ```
 
 4. View the website at <http://localhost:4000/docs/>
+
+### Docker
+
+If you would prefer to [install Docker][install-docker] and [Docker Compose][install-docker-compose]
+rather than Ruby directly, these can be used instead.
+
+Note that this approach exposes the development server to the network you're
+using, which may present a security risk.
 
 ## Making changes
 
@@ -58,6 +60,8 @@ page titles.
 
 [clone-repo]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
 [install-ruby]: https://www.ruby-lang.org/en/documentation/installation/
+[install-docker]: https://docs.docker.com/engine/install/
+[install-docker-compose]: https://docs.docker.com/compose/install/
 [raise-a-pr]: https://github.com/srobo/docs/pull/new/master
 [cspell]: https://cspell.org/
 [vscode-cspell]: https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Once setup, the site will be accessible on http://localhost:4000/docs/
 When you've made a change, either push it to a forked repository, or to a
 feature branch, and [raise a pull request][raise-a-pr].
 
+### Spellings
+
+Spell checking is provided via [`cspell`][cspell], a library which integrates
+with a number of code editors. Checking is run automatically on pull requests.
+
+If you're using VSCode, be sure to [install Code Spell Checker][vscode-cspell].
+
+To run the checks manually (this is optional) you'll need to:
+
+0. install [NodeJS & `npm`][install-node]
+
+1. run `npm test`
+
+New spellings can be added to `.spelling`. Be sure to spell added words correctly!
+
 ### Navigation Sidebar
 
 The docs navigation sidebar is generated from `_data/sidebar_tree.yaml` as part
@@ -42,3 +57,6 @@ page titles.
 [clone-repo]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
 [install-ruby]: https://www.ruby-lang.org/en/documentation/installation/
 [raise-a-pr]: https://github.com/srobo/docs/pull/new/master
+[cspell]: https://cspell.org/
+[vscode-cspell]: https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker
+[install-node]: https://downloads.nodesource.com/

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ Once setup, the site will be accessible on http://localhost:4000/docs/
 When you've made a change, either push it to a forked repository, or to a
 feature branch, and [raise a pull request][raise-a-pr].
 
-[clone-repo]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
-[install-ruby]: https://www.ruby-lang.org/en/documentation/installation/
-[raise-a-pr]: https://github.com/srobo/docs/pull/new/master
-
 ### Navigation Sidebar
 
 The docs navigation sidebar is generated from `_data/sidebar_tree.yaml` as part
 of the build process. This file is manually updated so that we can
 explicitly control which files are included, in what order as well as adjust the
 page titles.
+
+
+[clone-repo]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
+[install-ruby]: https://www.ruby-lang.org/en/documentation/installation/
+[raise-a-pr]: https://github.com/srobo/docs/pull/new/master


### PR DESCRIPTION
This aims to make the process easier for people not already familiar with the setup, primarily by guiding them through the preferred (local install) path which has each of the necessary steps laid out. It also explains how to run the spell checking locally.

Finally it calls out the security risks associated with the Docker path, removes the instructions there to reduce the chances that people not equipped to judge those risks take that path and implies (correctly) that the spell checking is not supported under Docker.