### PR TITLE
Normalise the JSON redirects file before diffing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,6 +121,28 @@ jobs:
           popd
           mv artifact.tar main.tar
 
+      - name: Normalise JSON
+        shell: python
+        run: |
+          import json
+          from pathlib import Path
+
+          ROOTS = [
+              Path('main'),
+              Path('local'),
+          ]
+          FILES = [
+              'redirects.json',
+          ]
+
+          for root in ROOTS:
+              for name in FILES:
+                  p = root / name
+                  p.write_text(json.dumps(
+                      json.loads(p.read_text()),
+                      sort_keys=True,
+                  ))
+
       - name: Diff
         id: diff
         run: |

--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,7 @@ user_tracking: true
 
 exclude:
   - README.md
+  - cspell.json
   - Rakefile
   - Gemfile
   - Gemfile.lock
@@ -63,6 +64,8 @@ exclude:
   - Dockerfile
   - docker-compose.yml
   - node_modules/
+  - package-lock.json
+  - package.json
   - _env/
   - _docs/
   - vendor/


### PR DESCRIPTION
This ensures that key-ordering changes, which don't affect the semantics of the file, don't create diff noise (such as that in https://github.com/srobo/docs/pull/597#issuecomment-2264369027).

Also exclude some build-time JSON files from the output.

Builds on #600 to pick up that fix.