### PR TITLE
Move to using Docker Compose v2 explicitly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build container
-      run: docker-compose build
+      run: docker compose build
 
     - name: Build site in container
-      run: docker-compose run docs rake build
+      run: docker compose run docs rake build
 
   changes:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Student Robotics public documentation.
 
 ## Getting Started
 
-For ease of setup, a Docker container is provided. Simply install Docker and `docker-compose`, and run `docker-compose up`.
+For ease of setup, a Docker container is provided. Simply install Docker and `docker-compose`, and run `docker compose up`.
 
 Once setup, the site will be accessible on http://localhost:4000/docs/
 


### PR DESCRIPTION
GitHub have removed v1 from their CI images, see https://github.com/actions/runner-images/issues/9692.

I thiiink this is what was already expected since the compose file is labelled as v2, though I don't know enough about docker compose to be sure.