### PR TITLE
Use a consistent mechanism to upload our reference build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,11 +82,10 @@ jobs:
       - name: Build
         run: rake build
 
-      - name: Upload build site
-        uses: actions/upload-artifact@v4
+      - name: Upload reference artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           name: build-from-main
-          path: _site
 
   diff:
     runs-on: ubuntu-latest
@@ -113,7 +112,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-from-main
-          path: main
+
+      - name: Unpack main build
+        run: |
+          mkdir main
+          pushd main
+          tar --extract --file ../artifact.tar
+          popd
+          mv artifact.tar main.tar
 
       - name: Diff
         id: diff


### PR DESCRIPTION
Something changed recently in how actions/upload-artifact creates its archives, such that symlinked files behaved differently under that action than under actions/upload-pages-artifact. This broke our diffing logic.

Move to using the same upload approach for both the local and reference main builds, to avoid spurious errors.