### PR TITLE
Provide more information for supervisors

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -80,6 +80,8 @@ tree:
   - url: /robots_101/
     title: Robots 101
     tree:
+      - url: /robots_101/programme_structure
+        title: Programme Structure
       - url: /robots_101/post_kickstart
         title: After Kickstart
       - url: /robots_101/design

--- a/robots_101/index.md
+++ b/robots_101/index.md
@@ -7,7 +7,9 @@ title: Robots 101
 
 Robots 101 is a series aimed at helping teams new to Student Robotics get started.
 
-There are 6 articles in this series:
+There are 7 articles in this series:
+
+- [Programme Structure]({{ site.baseurl }}/robots_101/programme_structure): What happens during the course of the year
 - [Post-Kickstart]({{ site.baseurl }}/robots_101/post_kickstart): You've attended our Kickstart event and are now ready to build your robot
 - [Design]({{ site.baseurl }}/robots_101/design): How to approach the design of your robot
 - [Code]({{ site.baseurl }}/robots_101/code): Things to consider when writing code for your robot

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -10,7 +10,7 @@ But what actually happens during the course of the competition year?
 
 ## Registration
 
-Registration for the competition usually opens in late summer. Teams usually
+Registration for the competition usually opens in early September. Teams usually
 consist of 4-8 competitors attending a school or college, though other groups
 are also free to enter. Your team must have a responsible adult who will oversee
 the team (a role we call the [team supervisor][team-supervisor]) and they must

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -10,7 +10,7 @@ But what actually happens during the course of the competition year?
 
 ## Registration
 
-Registration for the competition usually open in late summer. Teams usually
+Registration for the competition usually opens in late summer. Teams usually
 consist of 4-8 competitors attending a school or college, though other groups
 are also free to enter. Your team must have a responsible adult who will oversee
 the team (a role we call the [team supervisor][team-supervisor]) and they must

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -65,6 +65,14 @@ more direct help with your robot.
 We provide a space for you to work in, with power and internet access, as well
 as volunteers able to help with the kits and hands-on guidance with your robot.
 
+## Virtual Competition
+
+The Virtual Competition is often the first change you'll have to test your
+strategies against other teams. You'll submit your robot code for running
+against other teams in the [simulator][simulator]. The matches are livestreamed
+on our [YouTube Channel][youtube] and you'll get a copy of your robot's logs
+afterwards so you can continue to improve it.
+
 ## Competition
 
 The Competition event is a two day event in spring. You'll put your robot to the
@@ -88,3 +96,5 @@ afternoon you'll advance into the knockout stages, and can go on to win prizes.
 [kit]: {{ site.baseurl }}/kit/
 [discord]: {{ site.baseurl }}/tutorials/discord
 [tech-days]: {{ site.baseurl }}/robots_101/tech_days
+[simulator]: {{ site.baseurl }}/simulator/
+[youtube]: https://www.youtube.com/@studentrobotics

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -75,8 +75,8 @@ afterwards so you can continue to improve it.
 
 ## Competition
 
-The Competition event is a two day event in spring. You'll put your robot to the
-test in a weekend of tinkering and matches.
+The Competition event is a two day event in spring. It's the ultimate test for
+your robot in a weekend of tinkering and matches.
 
 You'll have a team pit for you to work in, with power and internet access, and
 throughout the weekend there are volunteers around to help with the kits and

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -13,7 +13,12 @@ But what actually happens during the course of the competition year?
 Registration for the competition usually open in late summer. Teams usually
 consist of 4-8 competitors attending a school or college, though other groups
 are also free to enter. Your team must have a responsible adult who will oversee
-the team -- a role we call the [team supervisor][team-supervisor].
+the team (a role we call the [team supervisor][team-supervisor]) and they must
+be the person to [sign up][sign-up].
+
+While places are free (thanks to our [sponsors][sponsors]), they are limited.
+You will be notified whether or not your team has received a place shortly
+before the start of the competition year.
 
 <!-- TODO: add something about the pre-kickstart activities once they're published -->
 
@@ -76,6 +81,8 @@ afternoon you'll advance into the knockout stages, and can go on to win prizes.
 
 
 [team-supervisor]: {{ site.baseurl }}/robots_101/team_supervisor
+[sign-up]: https://studentrobotics.org/compete/#signup
+[sponsors]: https://studentrobotics.org/sponsor/
 [microgames]: {{ site.baseurl }}/competitor_resources/microgames
 [kit]: {{ site.baseurl }}/kit/
 [discord]: {{ site.baseurl }}/tutorials/discord

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -1,0 +1,82 @@
+---
+layout: page
+title: Robots 101 - Programme Structure
+---
+
+# Robots 101 - Programme Structure
+
+Student Robotics is an annual robotics competition for people aged 16-19.
+But what actually happens during the course of the competition year?
+
+## Registration
+
+Registration for the competition usually open in late summer. Teams usually
+consist of 4-8 competitors attending a school or college, though other groups
+are also free to enter. Your team must have a responsible adult who will oversee
+the team -- a role we call the [team supervisor][team-supervisor].
+
+<!-- TODO: add something about the pre-kickstart activities once they're published -->
+
+## Kickstart
+
+Kickstart is the event which kicks off a competition year. The structure of the
+competition and the game rules are announced and any questions you have will be
+answered.
+
+Typically this is a one day in-person event in October (usually a Saturday).
+Throughout the day there are Blueshirts (our awesome volunteers!) around in
+person, ready to answer any questions and to help you through the
+[microgames][microgames]. The microgames help you become familiar with the
+[kit][kit] which is loaned to all teams and should kickstart some ideas for your
+robot’s design.
+
+## Mentoring
+
+Shortly after Kickstart we aim to pair up teams with a volunteer mentor who can
+guide the team and help them with any technical questions. Where possible the
+mentor will join the team's meetings in person, though we also offer remote
+mentors if that is not possible.
+
+All teams also have access to our [Discord][discord] server where they can chat
+with all our volunteers (as well as other teams) at any time.
+
+## Your time
+
+Most teams work on their robot for at least two hours a week, with some teams
+spending four hours or more. How this time is scheduled varies between teams --
+some have more than one meeting a week, others have less frequent but longer
+sessions.
+
+To get the most out of the time, ensure sessions are long enough to make useful
+progress after allowing for setting up beforehand and tidying away afterwards.
+
+## Tech Days
+
+Throughout the year [Tech Days][tech-days] provide opportunities to spend a
+whole day (usually a Saturday) working on your robot, with lots of help
+available. They’re also an opportunity to see how other teams are doing or get
+more direct help with your robot.
+
+We provide a space for you to work in, with power and internet access, as well
+as volunteers able to help with the kits and hands-on guidance with your robot.
+
+## Competition
+
+The Competition event is a two day event in spring. You'll put your robot to the
+test in a weekend of tinkering and matches.
+
+You'll have a team pit for you to work in, with power and internet access, and
+throughout the weekend there are volunteers around to help with the kits and
+hands-on guidance with your robot. We also provide a test arena which you can
+use to check the improvements you're making to your robot.
+
+Typically there are blocks of league matches on the Saturday and on Sunday
+morning, with time to improve your robot between appearances. On Sunday
+afternoon you'll advance into the knockout stages, and can go on to win prizes.
+
+
+[team-supervisor]: {{ site.baseurl }}/robots_101/team_supervisor
+[microgames]: {{ site.baseurl }}/competitor_resources/microgames
+[kit]: {{ site.baseurl }}/kit/
+[discord]: {{ site.baseurl }}/tutorials/discord
+[tech-days]: {{ site.baseurl }}/robots_101/tech_days

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -25,8 +25,8 @@ before the start of the competition year.
 ## Kickstart
 
 Kickstart is the event which kicks off a competition year. The structure of the
-competition and the game rules are announced and any questions you have will be
-answered.
+competition and the [game rules][rules] are announced and any questions you have
+will be answered.
 
 Typically this is a one day in-person event in October (usually a Saturday).
 Throughout the day there are Blueshirts (our awesome volunteers!) around in
@@ -83,6 +83,7 @@ afternoon you'll advance into the knockout stages, and can go on to win prizes.
 [team-supervisor]: {{ site.baseurl }}/robots_101/team_supervisor
 [sign-up]: https://studentrobotics.org/compete/#signup
 [sponsors]: https://studentrobotics.org/sponsor/
+[rules]: {{ site.baseurl }}/rules/
 [microgames]: {{ site.baseurl }}/competitor_resources/microgames
 [kit]: {{ site.baseurl }}/kit/
 [discord]: {{ site.baseurl }}/tutorials/discord

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -48,6 +48,11 @@ Popular suppliers of these components are:
 - [Amazon](https://www.amazon.co.uk/)
 - [eBay](https://www.ebay.co.uk/)
 
+Your team will also need access to a computer to write the code for their robot.
+Ideally this would be one that can be brought to events so that improvements can be made to the robot at any time.
+
+Being able to install software onto the computer will also be important to make use of the [simulator]({{ site.baseurl }}/simulator/) and a suitable [code editor]({{ site.baseurl }}/tutorials/editors/).
+
 ## Support
 
 To allow you and your team to ask us questions directly, as well as share what they’re working on with other teams, we provide a [Discord]({{ site.baseurl }}/tutorials/discord) server. You will receive a unique link to share with your team so that you can all join with your own Discord accounts. Each team gets a private text channel for direct support from us which can be used to discuss your robot without worrying about giving other teams your strategy. We also have a team-supervisor only channel for any questions you may have. There are also some text channels where teams can communicate with each other (and us!) for more general topics. If you’d like a voice channel for your team, email us or ask in `#team-supervisor`!

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -9,7 +9,9 @@ Here’s a little bit of info on what to expect from Student Robotics, and your 
 
 ## Your role
 
-As a team supervisor, your role is to guide the competitors through the journey of building a robot. You’ll be there to point them in the right direction when they get stuck and resolve any issues they run into. We encourage team supervisors to limit their involvement with the robot design/building process so that the finished contraptions are 100% student-built which competitors find very rewarding.
+As a team supervisor, your role is to guide the competitors through the journey of building a robot. You’ll be there to point them in the right direction when they get stuck and resolve any issues they run into.
+You don't need to have any technical skills though -- our volunteer mentors can provide that [support](#support) either in person or remotely.
+We encourage team supervisors to limit their involvement with the robot design/building process so that the finished contraptions are 100% student-built which competitors find very rewarding.
 
 You’ll be our point of contact with the team. If you have any questions during the year, just email <{{ site.emails.teams }}>. We’ll also be sending you emails every month or so with important information such as:
 - Details of [Tech Days]({{ site.baseurl }}/robots_101/tech_days) where we provide a space for teams to come together and get direct help from our dedicated volunteers

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -17,7 +17,7 @@ You’ll be our point of contact with the team. If you have any questions during
 We aim to host our Kickstart event and Tech Days in multiple locations to make it more convenient for you to travel. However, you will still need to arrange to travel to these places.
 This is especially important to book for the competition, as you will likely need to arrange to stay overnight near the venue.
 
-Our kit includes a battery and a few boards to get your robot started. However, your team will need additional components and materials from which to build their robot. For the chassis, your team has several options. Teams often use cardboard, MDF, Aluminium, and/or Acrylic. In terms of electronic components, teams often make use of:
+Our [kit]({{ site.baseurl }}/kit/) includes a battery and a few boards to get your robot started. However, your team will need additional components and materials from which to build their robot. For the chassis, your team has several options. Teams often use cardboard, MDF, Aluminium, and/or Acrylic. In terms of electronic components, teams often make use of:
 - At least two 12V motors (our kit supports four)
 - A few servo motors
 - A few microswitches for detecting if you bump into something

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -7,6 +7,8 @@ title: Robots 101 - So you're running a team
 
 Here’s a little bit of info on what to expect from Student Robotics, and your responsibilities as a team supervisor.
 
+## Your role
+
 As a team supervisor, your role is to guide the competitors through the journey of building a robot. You’ll be there to point them in the right direction when they get stuck and resolve any issues they run into. We encourage team supervisors to limit their involvement with the robot design/building process so that the finished contraptions are 100% student-built which competitors find very rewarding.
 
 You’ll be our point of contact with the team. If you have any questions during the year, just email <{{ site.emails.teams }}>. We’ll also be sending you emails every month or so with important information such as:
@@ -16,6 +18,8 @@ You’ll be our point of contact with the team. If you have any questions during
 
 We aim to host our Kickstart event and Tech Days in multiple locations to make it more convenient for you to travel. However, you will still need to arrange to travel to these places.
 This is especially important to book for the competition, as you will likely need to arrange to stay overnight near the venue.
+
+## Materials
 
 Our [kit]({{ site.baseurl }}/kit/) includes a battery and a few boards to get your robot started. However, your team will need additional components and materials from which to build their robot. For the chassis, your team has several options. Teams often use cardboard, MDF, Aluminium, and/or Acrylic. In terms of electronic components, teams often make use of:
 - At least two 12V motors (our kit supports four)
@@ -32,6 +36,8 @@ Popular suppliers of these components are:
 - [Farnell](https://uk.farnell.com/)
 - [Amazon](https://www.amazon.co.uk/)
 - [eBay](https://www.ebay.co.uk/)
+
+## Support
 
 To allow you and your team to ask us questions directly, as well as share what they’re working on with other teams, we provide a [Discord]({{ site.baseurl }}/tutorials/discord) server. You will receive a unique link to share with your team so that you can all join with your own Discord accounts. Each team gets a private text channel for direct support from us which can be used to discuss your robot without worrying about giving other teams your strategy. We also have a team-supervisor only channel for any questions you may have. There are also some text channels where teams can communicate with each other (and us!) for more general topics. If you’d like a voice channel for your team, email us or ask in `#team-supervisor`!
 

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -21,6 +21,15 @@ You’ll be our point of contact with the team. If you have any questions during
 We aim to host our Kickstart event and Tech Days in multiple locations to make it more convenient for you to travel. However, you will still need to arrange to travel to these places.
 This is especially important to book for the competition, as you will likely need to arrange to stay overnight near the venue.
 
+## The team
+
+Teams usually consist of 4-8 competitors aged 16-19 and are often attending a school or college.
+However, the team doesn't necessarily need to represent a school -- any group of 16-19 year-olds, with a responsible adult, can enter.
+
+Most teams work on their robot for at least two hours a week, with some teams spending four hours or more.
+How this time is scheduled varies between teams -- some have more than one meeting a week, others have less frequent but longer sessions.
+To get the most out of the time, ensure sessions are long enough to make useful progress after allowing for setting up beforehand and tidying away afterwards.
+
 ## Materials
 
 Our [kit]({{ site.baseurl }}/kit/) includes a battery and a few boards to get your robot started. However, your team will need additional components and materials from which to build their robot. For the chassis, your team has several options. Teams often use cardboard, MDF, Aluminium, and/or Acrylic. In terms of electronic components, teams often make use of:

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -16,7 +16,7 @@ We encourage team supervisors to limit their involvement with the robot design/b
 You’ll be our point of contact with the team. If you have any questions during the year, just email <{{ site.emails.teams }}>. We’ll also be sending you emails every month or so with important information such as:
 - Details of [Tech Days]({{ site.baseurl }}/robots_101/tech_days) where we provide a space for teams to come together and get direct help from our dedicated volunteers
 - Software updates for our kit
-- Information about the competition event (usually in late March or April)
+- Information about the [competition event]({{ site.baseurl }}/robots_101/programme_structure#competition) (usually in late March or April)
 
 We aim to host our Kickstart event and Tech Days in multiple locations to make it more convenient for you to travel. However, you will still need to arrange to travel to these places.
 This is especially important to book for the competition, as you will likely need to arrange to stay overnight near the venue.

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -11,7 +11,7 @@ Here’s a little bit of info on what to expect from Student Robotics, and your 
 
 As a team supervisor, your role is to guide the competitors through the journey of building a robot. You’ll be there to point them in the right direction when they get stuck and resolve any issues they run into.
 You don't need to have any technical skills though -- our volunteer mentors can provide that [support](#support) either in person or remotely.
-We encourage team supervisors to limit their involvement with the robot design/building process so that the finished contraptions are 100% student-built which competitors find very rewarding.
+We encourage team supervisors to limit their involvement with the [robot design]({{ site.baseurl }}/robots_101/design)/building process so that the finished contraptions are 100% student-built which competitors find very rewarding.
 
 You’ll be our point of contact with the team. If you have any questions during the year, just email <{{ site.emails.teams }}>. We’ll also be sending you emails every month or so with important information such as:
 - Details of [Tech Days]({{ site.baseurl }}/robots_101/tech_days) where we provide a space for teams to come together and get direct help from our dedicated volunteers
@@ -48,7 +48,7 @@ Popular suppliers of these components are:
 - [Amazon](https://www.amazon.co.uk/)
 - [eBay](https://www.ebay.co.uk/)
 
-Your team will also need access to a computer to write the code for their robot.
+Your team will also need access to a computer to write the [code]({{ site.baseurl }}/robots_101/code) for their robot.
 Ideally this would be one that can be brought to events so that improvements can be made to the robot at any time.
 
 Being able to install software onto the computer will also be important to make use of the [simulator]({{ site.baseurl }}/simulator/) and a suitable [code editor]({{ site.baseurl }}/tutorials/editors/).


### PR DESCRIPTION
This extends the supervisor page and adds a new page about the overall programme structure. The goal here is to address the key aspects of https://github.com/srobo/tasks/issues/1357, though to fully complete that we'll also need to actually get these docs in front of supervisors early in the cycle.

This may also go some way towards other issues linked from that one, though I don't think fully addresses any single one of them. Again this is partly about getting the information in other places (though hopefully this is now something we can more easily/usefully link to).

As part of this change I've also linked to the team-supervisor ("Running a team") page from the signup form for SR2025. Ideally we'd include this change before that goes live, but even as it stands it's a useful resource for them.

Ideally I'd also like to have a separate page just about the competition event, but that can wait for another time. (Also I believe there's already a [draft somewhere](https://docs.google.com/document/d/1khsxcb84PZPm0071Vwkz4JfBY3z-xruAc9cs8UmUMSw/edit), which could usefully be finished)