### PR TITLE
Add documentation for kit return

### DIFF
--- a/kit/return.md
+++ b/kit/return.md
@@ -15,7 +15,7 @@ Be sure to take all of your own kit with you - it may not be possible to return 
 
 ## Kit Shipping
 
-If you are unable to return your kit at the competition, it must be shipped to us at <a href="{{ site.url }}/contact/">this address</a>, unless otherwise instructed.
+If you are unable to return your kit at the competition, it must be shipped to us at [this address]({{ site.url }}/contact/), unless otherwise instructed.
 
 The Kit List document included with your kit has the date by which the kit needs to be returned.
 

--- a/kit/return.md
+++ b/kit/return.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: Kit Return
+---
+
+# Kit Return
+
+All items [provided](/docs/kit/) in the kit, with the exception of wire, must be returned at the end of the competition. The Kit List document included with your kit has a list of items included in the kit.
+
+After the competition event, you will need to extract the kit from your robot and return them. If you are not using every component of the kit, it should still be brought to the competition so it can be returned. Your returned kit will be checked as you leave the venue. If you have forgotten any items, they must be returned as soon as possible after the event.
+
+<div class="info">
+Be sure to take all of your own kit with you - it may not be possible to return forgotten items to you promptly.
+</div>
+
+## Kit Shipping
+
+If you are unable to return your kit at the competition, it must be shipped to us at <a href="{{ site.url }}/contact/">this address</a>, unless otherwise instructed.
+
+The Kit List document included with your kit has the date by which the kit needs to be returned.
+
+When packaging your kit for shipping, we recommend securely packing everything inside the white Really Useful Box (RUB). The RUB may also need to be packed in an appropriately sized double-walled cardboard box. Any space between the RUB and the cardboard box should be packed with an appropriate paper-based filler material. Inside the RUB, All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap, and excess empty space filled with paper or bubble wrap.
+
+<div class="warning">Batteries must be shipped in the protective battery bag.</div>
+
+If you are not returning a complete kit, similar precautions should be used to ensure the kit arrives undamaged.
+
+### Details for couriers
+
+When shipping the kit with your courier of choice, they may require specific details about the kit:
+
+- Description: Robotics kit
+- Dimensions: 48cm x 39cm x 20cm
+- Weight: 6kg (A kit weighs approx. 4.95kg; 6kg gives some headroom)
+- Value (for insurance): £500
+- Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
+
+In all circumstances a shipment of a kit must have at least £500 worth of insurance.
+
+A LiPo warning sticker (UN3481) must be affixed to the outside of the box.


### PR DESCRIPTION
We often send teams details of kit return when they drop out, but it's probably a good idea to have it generally available.

This information was derived from previous competitions, and the [Kit Shipping](https://studentrobotics.org/runbook/kit/logistics/transport/) pages of the runbook.