### PR TITLE
Add some links to the kit return page

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -32,6 +32,8 @@ tree:
       title: Servo Board
     - url: /kit/arduino
       title: Arduino
+    - url: /kit/return
+      title: Kit Return
   - url: /programming/
     title: Programming
     tree:

--- a/kit/index.md
+++ b/kit/index.md
@@ -6,7 +6,7 @@ title: Kit
 # Kit
 
 The Student Robotics kit is lent, free of charge, to each team and consists of various modules designed by us along with some ancillary parts to allow easy use of the modules.
-All of the kit, except the wire, needs to be returned after the competition.
+All of the kit, except the wire, needs to be [returned](/docs/kit/return) after the competition.
 
 
 ## The Modules


### PR DESCRIPTION
This makes the loan nature even clearer as people will more easily know what they're getting themselves into.