### PR TITLE
Drop explicit webrick dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,3 @@ gem 'html-proofer', '~> 4'
 
 # Avoid polling on windows
 gem 'wdm', '>= 0.1.0'
-
-# For local Ruby 3 support; works around https://github.com/github/pages-gem/issues/752
-gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,6 @@ DEPENDENCIES
   neat
   rake
   wdm (>= 0.1.0)
-  webrick (~> 1.7)
 
 BUNDLED WITH
    2.3.6


### PR DESCRIPTION
The related bug has since been fixed (and we appear to have already pulled it in).

See also:
- https://github.com/srobo/competition-website/pull/61
- https://github.com/srobo/style/pull/53
- https://github.com/srobo/website/pull/585