### PR TITLE
Add general information about our events

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -84,6 +84,8 @@ tree:
     tree:
       - url: /robots_101/programme_structure
         title: Programme Structure
+      - url: /robots_101/events
+        title: Events
       - url: /robots_101/post_kickstart
         title: After Kickstart
       - url: /robots_101/design

--- a/robots_101/events.md
+++ b/robots_101/events.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: Robots 101 - Events
+---
+
+# Robots 101 - Events
+
+There are three types of event which are held through the [competition year][structure]:
+
+* [Kickstart][kickstart]
+* [Tech Days][tech-days]
+* [Competition][competition]
+
+All events are listed in the [events calendar][events-calendar] on our website.
+The event page for each one contain details of when & where they are, along with
+anything specific you'll need for the day. Generally you will be provided with
+power and internet access, as well as a space to work on your robot, though each
+event is different so be sure to check the event pages.
+
+All teams attending an event **must** be accompanied by a responsible adult.
+This person will typically be the primary Team Supervisor, however does not need
+to be. In cases where this role is delegated, we require only that:
+
+* the person is someone the primary contact is aware of and happy to act as [Team Supervisor][team-supervisor] in their stead at the event:
+  * over the age of 18
+  * not a competitor
+  * able to take responsibility for all their competitors at the event, as well as any equipment brought by the team
+* the primary contact inform us who the person is ahead of the event and provide a mobile phone number which we can use to contact them if needed
+
+For events which have dedicated sign-up forms (usually this is just Tech Days),
+we usually include a way to indicate who will be responsible for the competitors.
+Otherwise, or if your plans change, please [email us](mailto:{{ site.emails.teams }}).
+
+
+[structure]: {{ site.baseurl }}/robots_101/programme_structure
+[kickstart]: {{ site.baseurl }}/robots_101/programme_structure#kickstart
+[tech-days]: {{ site.baseurl }}/robots_101/tech_days
+[competition]: {{ site.baseurl }}/robots_101/programme_structure#competition
+[events-calendar]: https://studentrobotics.org/events/
+[team-supervisor]: {{ site.baseurl }}/robots_101/team_supervisor

--- a/robots_101/events.md
+++ b/robots_101/events.md
@@ -19,7 +19,7 @@ event is different so be sure to check the event pages.
 
 All teams attending an event **must** be accompanied by a responsible adult.
 This person will typically be the primary Team Supervisor, however does not need
-to be. In cases where this role is delegated, we require only that:
+to be. In cases where this role is delegated, we require that:
 
 * the person is someone the primary contact is aware of and happy to act as [Team Supervisor][team-supervisor] in their stead at the event:
   * over the age of 18

--- a/robots_101/index.md
+++ b/robots_101/index.md
@@ -7,9 +7,10 @@ title: Robots 101
 
 Robots 101 is a series aimed at helping teams new to Student Robotics get started.
 
-There are 7 articles in this series:
+There are 8 articles in this series:
 
 - [Programme Structure]({{ site.baseurl }}/robots_101/programme_structure): What happens during the course of the year
+- [Events]({{ site.baseurl }}/robots_101/events): General information about our events
 - [Post-Kickstart]({{ site.baseurl }}/robots_101/post_kickstart): You've attended our Kickstart event and are now ready to build your robot
 - [Design]({{ site.baseurl }}/robots_101/design): How to approach the design of your robot
 - [Code]({{ site.baseurl }}/robots_101/code): Things to consider when writing code for your robot

--- a/robots_101/post_kickstart.md
+++ b/robots_101/post_kickstart.md
@@ -5,7 +5,7 @@ title: Robots 101 - Kickstarted, now what?
 
 # Robots 101 - Kickstarted, now what?
 
-So, you attended our kickstart event and are now ready to build your robot! But where should you start? We’re here to help!
+So, you attended our [kickstart event][kickstart] and are now ready to build your robot! But where should you start? We’re here to help!
 
 We’ve found that most teams split up the different parts of the robot between them. It’s a good idea to meet up and discuss which tasks each person wants to accomplish and give each other roles inside the team. Of course, these can change throughout the time between kickstart and competition, but make sure everyone has a job to do. It’s important to make sure there's always at least two or three people that can do each task type. Don’t forget tasks outside the robot itself either, like project management, running the social media, or theming.
 
@@ -19,6 +19,7 @@ As part of your team, you’ll have a trusted adult who is acting as supervisor 
 
 Hopefully this has given you some jumping off points to begin your journey to the competition. Check back soon for our next entry in this series, all about how to design your robot!
 
+[kickstart]: {{ site.baseurl }}/robots_101/programme_structure#kickstart
 [youtube]: https://youtube.com/user/StudentRobotics
 [discord-docs]: {{ site.baseurl }}/tutorials/discord
 [one-oh-one-supervisor]: {{ '/robots_101/team_supervisor' | prepend: site.baseurl }}

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -30,7 +30,7 @@ Kickstart is the event which kicks off a competition year. The structure of the
 competition and the [game rules][rules] are announced and any questions you have
 will be answered.
 
-Typically this is a one day in-person event in October (usually a Saturday).
+Typically this is a one day in-person [event][events] in October (usually a Saturday).
 Throughout the day there are Blueshirts (our awesome volunteers!) around in
 person, ready to answer any questions and to help you through the
 [microgames][microgames]. The microgames help you become familiar with the
@@ -95,6 +95,7 @@ afternoon you'll advance into the knockout stages, and can go on to win prizes.
 [sponsors]: https://studentrobotics.org/sponsor/
 [pre-kickstart-activities]: {{ site.baseurl }}/competitor_resources/pre_kickstart_activities
 [rules]: {{ site.baseurl }}/rules/
+[events]: {{ site.baseurl }}/robots_101/events
 [microgames]: {{ site.baseurl }}/competitor_resources/microgames
 [kit]: {{ site.baseurl }}/kit/
 [discord]: {{ site.baseurl }}/tutorials/discord

--- a/robots_101/team_supervisor.md
+++ b/robots_101/team_supervisor.md
@@ -18,7 +18,7 @@ You’ll be our point of contact with the team. If you have any questions during
 - Software updates for our kit
 - Information about the [competition event]({{ site.baseurl }}/robots_101/programme_structure#competition) (usually in late March or April)
 
-We aim to host our Kickstart event and Tech Days in multiple locations to make it more convenient for you to travel. However, you will still need to arrange to travel to these places.
+We aim to host our [Kickstart event]({{ site.baseurl }}/robots_101/programme_structure#kickstart) and Tech Days in multiple locations to make it more convenient for you to travel. However, you will still need to arrange to travel to these places.
 This is especially important to book for the competition, as you will likely need to arrange to stay overnight near the venue.
 
 ## The team

--- a/robots_101/tech_days.md
+++ b/robots_101/tech_days.md
@@ -50,6 +50,8 @@ anything specific you'll need for the day.
 Your Team Supervisor can sign up for your team to attend as many as you like,
 however in cases where events are over-subscribed we will try to ensure that
 everyone has the opportunity to attend at least one Tech Day throughout the
-year.
+year. Be sure to also read our general information about [events][events] when
+signing up.
 
 [events-calendar]: https://studentrobotics.org/events/
+[events]: {{ site.baseurl }}/robots_101/events


### PR DESCRIPTION
This mostly serves as a place to document that we don't require the primary contact to be the person who brings a team to our events, which is something that we're asked every year. We've pretty much always had the same policy, however tend to need to re-evaluate it every time it's asked as we haven't written it down.

Fixes https://github.com/srobo/tasks/issues/1475