### PR TITLE
Link sooner to the list of Tech Days for the current year

### DIFF
--- a/robots_101/tech_days.md
+++ b/robots_101/tech_days.md
@@ -5,6 +5,8 @@ title: Robots 101 - Tech Days
 
 # Robots 101 - Tech Days
 
+_See the Tech Days for this year in the [events calendar][events-calendar] on our website._
+
 Tech Days are opportunities for your team to spend a whole day working on your
 robot, with lots of help available. They’re also an opportunity to see how other
 teams are doing or get more direct help with your robot.


### PR DESCRIPTION
Now that we're linking to this page a bit more from various places, having an easy way from here to the events for the current year seems like it's useful.

![image](https://github.com/user-attachments/assets/2b471877-7691-4df4-8239-bfffcccfa7f1)