### PR TITLE
Move tutorial content to top of navbar

### DIFF
--- a/_data/sidebar_tree.yaml
+++ b/_data/sidebar_tree.yaml
@@ -3,6 +3,55 @@
 tree:
   - url: /
     title: Introduction
+
+  - url: /robots_101/
+    title: Robots 101
+    tree:
+      - url: /robots_101/programme_structure
+        title: Programme Structure
+      - url: /robots_101/post_kickstart
+        title: After Kickstart
+      - url: /robots_101/design
+        title: Design
+      - url: /robots_101/code
+        title: Code
+      - url: /robots_101/theming
+        title: Theming
+      - url: /robots_101/tech_days
+        title: Tech Days
+      - url: /robots_101/team_supervisor
+        title: Running a team
+  - url: /tutorials/
+    title: Tutorials
+    tree:
+    - url: /tutorials/assembly
+      title: Kit Assembly
+    - url: /tutorials/python
+      title: An intro to Python
+    - url: /tutorials/getting_code_on_the_robot
+      title: Getting Code on the Robot
+    - url: /tutorials/basic_motor_control
+      title: Basic Motor Control
+    - url: /tutorials/editors/
+      title: Code Editors
+      tree:
+      - url: /tutorials/editors/pycharm
+        title: PyCharm
+      - url: /tutorials/editors/vscode
+        title: Visual Studio Code
+    - url: /tutorials/update_brain
+      title: Updating your brain board
+    - url: /tutorials/discord
+      title: How to use Discord
+  - url: /rules/
+    title: Rules
+    tree:
+    #- url: /rules/code_of_conduct
+    #  title: Code Of Conduct
+    #- url: /rules/safety_regulations
+    #  title: Safety Regulations
+    - url: /rules/archive
+      title: Game Rules Archive
   - url: /kit/
     title: Kit
     tree:
@@ -70,54 +119,6 @@ tree:
         title: Custom Firmware
     - url: /programming/cheat_sheet
       title: API Quick Reference
-  - url: /rules/
-    title: Rules
-    tree:
-    #- url: /rules/code_of_conduct
-    #  title: Code Of Conduct
-    #- url: /rules/safety_regulations
-    #  title: Safety Regulations
-    - url: /rules/archive
-      title: Game Rules Archive
-  - url: /robots_101/
-    title: Robots 101
-    tree:
-      - url: /robots_101/programme_structure
-        title: Programme Structure
-      - url: /robots_101/post_kickstart
-        title: After Kickstart
-      - url: /robots_101/design
-        title: Design
-      - url: /robots_101/code
-        title: Code
-      - url: /robots_101/theming
-        title: Theming
-      - url: /robots_101/tech_days
-        title: Tech Days
-      - url: /robots_101/team_supervisor
-        title: Running a team
-  - url: /tutorials/
-    title: Tutorials
-    tree:
-    - url: /tutorials/assembly
-      title: Kit Assembly
-    - url: /tutorials/python
-      title: An intro to Python
-    - url: /tutorials/getting_code_on_the_robot
-      title: Getting Code on the Robot
-    - url: /tutorials/basic_motor_control
-      title: Basic Motor Control
-    - url: /tutorials/editors/
-      title: Code Editors
-      tree:
-      - url: /tutorials/editors/pycharm
-        title: PyCharm
-      - url: /tutorials/editors/vscode
-        title: Visual Studio Code
-    - url: /tutorials/update_brain
-      title: Updating your brain board
-    - url: /tutorials/discord
-      title: How to use Discord
   - url: /simulator/
     title: Simulator
     tree:
@@ -129,13 +130,6 @@ tree:
       title: The Simulated Robot
     - url: /simulator/troubleshooting
       title: Troubleshooting
-  - url: /troubleshooting/
-    title: Troubleshooting
-    tree:
-    - url: /troubleshooting/python
-      title: Python
-    - url: /troubleshooting/interactive_troubleshooter
-      title: Interactive Troubleshooter
   - url: /competitor_resources/
     title: Resources
     tree:
@@ -145,3 +139,10 @@ tree:
       title: Microgames
     - url: /competitor_resources/markers
       title: Game markers
+  - url: /troubleshooting/
+    title: Troubleshooting
+    tree:
+    - url: /troubleshooting/python
+      title: Python
+    - url: /troubleshooting/interactive_troubleshooter
+      title: Interactive Troubleshooter

--- a/index.md
+++ b/index.md
@@ -9,11 +9,11 @@ Introduction
 This documentation explains how to use the kit and the robot's Python API.
 The information is spread across multiple sections:
 
+- [Tutorials](/docs/tutorials/) are a series of guides that will help you get started.
+- The [rules](/docs/rules/) section is important as it talks through the aim of this year's game and what task you are trying to achieve.
 - The [kit](/docs/kit/) section will give you an overview of the physical kit that is provided to your team, how to connect to each board and what features they have.
 - The [programming](/docs/programming/) section talks through how to write code that interacts with all the boards.
 - The [simulator](/docs/simulator/) section explains how to use the simulator for testing your code, exploring strategies as well as preparing for the virtual competition.
-- The [rules](/docs/rules/) section is important as it talks through the aim of this year's game and what task you are trying to achieve.
-- [Tutorials](/docs/tutorials/) are a series of guides that will help you get started.
 
 Within this documentation, you will come across a number of boxes like this:
 


### PR DESCRIPTION
This makes them more prominent, and hopefully better used. The rest exists as a reference.

This is the pre-cursor for adding more tutorial style content.