### PR TITLE
Remove or reword most references to "simple" tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Student Robotics public documentation.
 
 ## Getting Started
 
-For ease of setup, a Docker container is provided. Simply install Docker and `docker-compose`, and run `docker compose up`.
+For ease of setup, a Docker container is provided. Install Docker and `docker-compose`, then run `docker compose up`.
 
 Once setup, the site will be accessible on http://localhost:4000/docs/
 

--- a/competitor_resources/pre_kickstart_activities.md
+++ b/competitor_resources/pre_kickstart_activities.md
@@ -5,7 +5,7 @@ title: Pre-Kickstart Activities
 
 # Pre-Kickstart Activities
 
-The pre-Kickstart activities are a new concept we are introducing for SR2025. They use our simulator for a set of activities intended to be completed between registration and Kickstart. These will teach some core concepts of robotics and introduce some simple sensors that teams could use on their physical robots.
+The pre-Kickstart activities are a new concept we are introducing for SR2025. They use our simulator for a set of activities intended to be completed between registration and Kickstart. These will teach some core concepts of robotics and introduce some basic sensors that teams could use on their physical robots.
 
 We recommend you work through them as a team, so you can learn from each other.
 If you have any issues, just ask us on [Discord](/docs/tutorials/discord).

--- a/programming/arduino/sr_firmware.md
+++ b/programming/arduino/sr_firmware.md
@@ -123,11 +123,11 @@ In this state, they might read high or low, or different values depending on the
 This is obviously not good for consistent control.
 
 Many pieces of off-the-shelf electronics that have some form of standard I/O output will connect this pin to 5.0V (high) and 0V (low) when required, so this is not a problem.
-However, for simple electronics, a microswitch for example, you would normally be required to connect a resistor between the input pin and 5.0V (a pull-up resistor) to keep the input in a known state until the switch overrides it by connecting directly to 0V.
+However, for basic electronics, a microswitch for example, you would normally be required to connect a resistor between the input pin and 5.0V (a pull-up resistor) to keep the input in a known state until the switch overrides it by connecting directly to 0V.
 
 However, the built-in pull-up resistor alleviates this need.
 It essentially wires in a resistor connected to 5.0V, meaning that when this option is enabled, an input pin will "default" to being high.
-This means you can simply connect a switch between the input pin and a ground pin without any need of resistors - when the switch is open, the pin will read high; when closed, it will read low.
+This means you can connect a switch between the input pin and a ground pin without any need of resistors - when the switch is open, the pin will read high; when closed, it will read low.
 
 ## Ultrasound Sensors
 

--- a/programming/robot_api/index.md
+++ b/programming/robot_api/index.md
@@ -10,7 +10,7 @@ title: Robot API
 Student Robotics has written a module &mdash; `sr.robot3`  &mdash; which is used to interface with the hardware.
 It handles all the low-level interactions so you don't have to.
 
-For example, to set the power of output 0 on a Motor Board to 30%, you would simply write:
+For example, to set the power of output 0 on a Motor Board to 30%, you would write:
 
 ~~~~~ python
 robot.motor_board.motors[0].power = 0.3

--- a/robots_101/design.md
+++ b/robots_101/design.md
@@ -11,7 +11,7 @@ The aim of this article is to give you a jumping off point rather than prescribe
 
 Before settling on a final design, it’s a good idea to devise several different strategies. Making a scale plan or model of the arena, tokens, and robots is a very good way to start thinking about these and can aid discussion. Be sure to document the pros and cons of each strategy. Include point scoring, ease of implementation, additional items required to implement the strategy, and possible interactions with other robots.
 
-Narrow the list and prototype some hardware (can be simple) to assess feasibility. The most complex, technologically advanced strategy is not necessarily the best. A simple (and elegant) strategy is more straightforward, quicker to implement and less likely to fail. On many occasions, a simple strategy has won the day.
+Narrow the list and prototype some hardware (can be basic) to assess feasibility. The most complex, technologically advanced strategy is not necessarily the best. A simple (and elegant) strategy is more straightforward, quicker to implement and less likely to fail. On many occasions, a simple strategy has won the day.
 
 ## Movement
 

--- a/robots_101/programme_structure.md
+++ b/robots_101/programme_structure.md
@@ -22,7 +22,7 @@ before the start of the competition year.
 
 We also provide some [pre-kickstart activities][pre-kickstart-activities] which
 teach some core concepts of robotics making use of our [simulator][simulator]
-and introduce some simple sensors that you could use on your physical robots.
+and introduce some basic sensors that you could use on your physical robots.
 
 ## Kickstart
 

--- a/tutorials/getting_code_on_the_robot.md
+++ b/tutorials/getting_code_on_the_robot.md
@@ -10,11 +10,10 @@ title: Getting Code on the Robot
 For your robot to function, it needs some code to tell it what to do.
 This code will be written on your computer, but then needs to be transferred to your robot to execute it.
 
-Getting your code on to the robot is quite simple.
 You will need to put your code on a USB drive which will need to be formatted with either FAT32, exFAT or ext2/3/4.
 Upon plugging in the drive or starting up, the robot will run the `robot.py` file found in the root of the drive.
 
-To re-run your program, simply remove the USB stick from the robot and plug it back in again and it will restart automatically.
+To re-run your program, remove the USB stick from the robot and plug it back in again and it will restart automatically.
 
 
 ## Windows

--- a/tutorials/python.md
+++ b/tutorials/python.md
@@ -50,7 +50,7 @@ print("Number of bees:", y - 2)
 
 The statements are executed one by one, in order. This example would give the output `Number of bees: 12`.
 
-As you may have guessed, the `print(...)` statement displays text on the screen, while the other two lines are simple algebra.
+As you may have guessed, the `print(...)` statement displays text on the screen, while the other two lines are basic algebra.
 
 ### Strings
 
@@ -85,7 +85,7 @@ This example would output `The answer is 42`, as the subtraction is not executed
 
 Variables store values for later use, as in the first example. They can store many different things, but the most relevant here are numbers, strings (blocks of text), booleans (`True` or `False`) and lists (which we'll come to later).
 
-To set a variable, simply give its name (see [Identifiers], below), followed by `=` and a value. For example:
+To set a variable, give its name (see [Identifiers], below), followed by `=` and a value. For example:
 
 ~~~~~ python
 x = 8
@@ -456,7 +456,7 @@ Try the same, but with the right angle in the top-right, like so (again, for inp
 [Calling functions](#calling-functions) {#calling-functions}
 -------------------
 
-Functions are pre-written bits of code that can be run ('called') at any point. The simplest functions take no parameters and return nothing. For example, the `exit` function ends your program prematurely:
+Functions are pre-written bits of code that can be run ('called') at any point. The most basic functions take no parameters and return nothing. For example, the `exit` function ends your program prematurely:
 
 ~~~~~ python
 x = 10

--- a/tutorials/update_brain.md
+++ b/tutorials/update_brain.md
@@ -14,7 +14,7 @@ The below will automatically calculate the latest version number, to be used whe
 # Updating your brain board
 
 The SD card is located on the underside of the board underneath the green power connector.
-Grab the SD card with your fingers and simply pull it out of the slot.
+Grab the SD card with your fingers and pull it out of the slot.
 
 To fully update your Brain Board's software, or refresh it if you think it's not working correctly, you can flash our SD card image onto the microSD card in your Brain Board.
 
@@ -25,7 +25,7 @@ The flashing procedure is identical to flashing Raspberry Pi images.
 
 ### Etcher
 
-We recommend using [Etcher](https://etcher.io), as it's simple to use, and available on Windows, macOS and Linux.
+We recommend using [Etcher](https://etcher.io), as it's designed for people of all skill levels, and is available on Windows, macOS and Linux.
 If you're familiar with Raspberry Pis or other similar boards and have flashed images before with a different tool, that should also work.
 
 ![Etcher example]({{ site.baseurl }}/images/content/kit/etcher.png)


### PR DESCRIPTION
Due to lack of knowledge, disability, additional needs, or other reasons I don't think we can call any task simple. This PR changes most references to simple to be more neutral by removing the word or rewording the sentence.