### PR TITLE
Install node in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,9 @@ COPY . ./
 
 RUN rake dependencies
 
+# Install nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash && apt install nodejs --yes
+
+RUN npm ci
+
 CMD ["rake", "dev"]


### PR DESCRIPTION
Fixes #488 

This lets it be used to run all checks.

Node is unpinned in the project, hence installing "current"