### PR TITLE
Drop 'neat' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'neat'
 gem 'kramdown'
 # jekyll depends on kramdown-parser-gfm, but fails to declare it
 gem 'kramdown-parser-gfm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     mini_portile2 (2.8.9)
-    neat (4.0.0)
-      thor (~> 0.19)
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -82,7 +80,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    thor (0.20.3)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     wdm (0.2.0)
@@ -100,7 +97,6 @@ DEPENDENCIES
   jekyll-redirect-from
   kramdown
   kramdown-parser-gfm
-  neat
   rake
   wdm (>= 0.1.0)
 


### PR DESCRIPTION
This is a SASS grid package, though as far as I can tell we're not using it. The [docs](https://neat.bourbon.io/) suggest we'd need to `@import "neat"` in our SASS files to be using it, which we're not. A cursory browse around the site also seems to work fine.

This also drops the `thor` package which has a pending security update.